### PR TITLE
8263531: Remove unused buffer int

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -121,7 +121,6 @@ class Http2Connection  {
 
     static private final int MAX_CLIENT_STREAM_ID = Integer.MAX_VALUE; // 2147483647
     static private final int MAX_SERVER_STREAM_ID = Integer.MAX_VALUE - 1; // 2147483646
-    static private final int BUFFER = 8; // added as an upper bound
 
     /**
      * Flag set when no more streams to be opened on this connection.


### PR DESCRIPTION
The change for JDK-8257001 left an obsolete int field. Remove it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263531](https://bugs.openjdk.java.net/browse/JDK-8263531): Remove unused buffer int


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/1.diff">https://git.openjdk.java.net/jdk17u/pull/1.diff</a>

</details>
