### PR TITLE
8262731: [macOS] Exception from "Printable.print" is swallowed during "PrinterJob.print"

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -33,6 +33,7 @@ import java.awt.print.*;
 import java.net.URI;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.print.*;
 import javax.print.attribute.PrintRequestAttributeSet;
@@ -60,6 +61,7 @@ public final class CPrinterJob extends RasterPrinterJob {
     private static String sShouldNotReachHere = "Should not reach here.";
 
     private volatile SecondaryLoop printingLoop;
+    private AtomicReference<Throwable> printErrorRef = new AtomicReference<>();
 
     private boolean noDefaultPrinter = false;
 
@@ -323,6 +325,7 @@ public final class CPrinterJob extends RasterPrinterJob {
                 performingPrinting = true;
                 userCancelled = false;
             }
+            printErrorRef.set(null);
 
             //Add support for PageRange
             PageRanges pr = (attributes == null) ?  null
@@ -380,6 +383,15 @@ public final class CPrinterJob extends RasterPrinterJob {
             }
             if (printingLoop != null) {
                 printingLoop.exit();
+            }
+
+            Throwable printError = printErrorRef.getAndSet(null);
+            if (printError != null) {
+                if (printError instanceof PrinterException) {
+                    throw (PrinterException) printError;
+                }
+                throw (PrinterException)
+                    new PrinterException().initCause(printError);
             }
         }
 
@@ -786,22 +798,36 @@ public final class CPrinterJob extends RasterPrinterJob {
     private Rectangle2D printAndGetPageFormatArea(final Printable printable, final Graphics graphics, final PageFormat pageFormat, final int pageIndex) {
         final Rectangle2D[] ret = new Rectangle2D[1];
 
-        Runnable r = new Runnable() { public void run() { synchronized(ret) {
-            try {
-                int pageResult = printable.print(graphics, pageFormat, pageIndex);
-                if (pageResult != Printable.NO_SUCH_PAGE) {
-                    ret[0] = getPageFormatArea(pageFormat);
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                synchronized (ret) {
+                    try {
+                        int pageResult = printable.print(
+                            graphics, pageFormat, pageIndex);
+                        if (pageResult != Printable.NO_SUCH_PAGE) {
+                            ret[0] = getPageFormatArea(pageFormat);
+                        }
+                    } catch (Throwable t) {
+                        printErrorRef.compareAndSet(null, t);
+                    }
                 }
-            } catch (Exception e) {} // Original code bailed on any exception
-        }}};
+            }
+        };
 
         if (onEventThread) {
-            try { EventQueue.invokeAndWait(r); } catch (Exception e) { e.printStackTrace(); }
+            try {
+                EventQueue.invokeAndWait(r);
+            } catch (Throwable t) {
+                printErrorRef.compareAndSet(null, t);
+            }
         } else {
             r.run();
         }
 
-        synchronized(ret) { return ret[0]; }
+        synchronized (ret) {
+            return ret[0];
+        }
     }
 
     // upcall from native

--- a/test/jdk/java/awt/print/PrinterJob/ExceptionFromPrintableIsIgnoredTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/ExceptionFromPrintableIsIgnoredTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8262731
+   @key headful printer
+   @summary Verify that "PrinterJob.print" throws the expected exception,
+            if "Printable.print" throws an exception.
+   @run main ExceptionFromPrintableIsIgnoredTest MAIN PE
+   @run main ExceptionFromPrintableIsIgnoredTest MAIN RE
+   @run main ExceptionFromPrintableIsIgnoredTest EDT PE
+   @run main ExceptionFromPrintableIsIgnoredTest EDT RE
+ */
+
+import java.awt.Graphics;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.SwingUtilities;
+
+public class ExceptionFromPrintableIsIgnoredTest {
+    private enum TestThreadType {MAIN, EDT}
+    private enum TestExceptionType {PE, RE}
+
+    private volatile Throwable printError;
+
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            throw new RuntimeException("Two arguments are expected:"
+                    + " test thread type and test exception type.");
+        }
+
+        new ExceptionFromPrintableIsIgnoredTest(
+            TestThreadType.valueOf(args[0]),
+            TestExceptionType.valueOf(args[1]));
+    }
+
+    public ExceptionFromPrintableIsIgnoredTest(
+            final TestThreadType threadType,
+            final TestExceptionType exceptionType) {
+        System.out.println(String.format(
+                "Test started. threadType='%s', exceptionType='%s'",
+                threadType, exceptionType));
+
+        String osName = System.getProperty("os.name");
+        boolean isOSX = osName.toLowerCase().startsWith("mac");
+        if ((exceptionType == TestExceptionType.RE) && !isOSX) {
+            System.out.println(
+                "Currently this test scenario can be verified only on macOS.");
+            return;
+        }
+
+        printError = null;
+
+        if (threadType == TestThreadType.MAIN) {
+            runTest(exceptionType);
+        } else if (threadType == TestThreadType.EDT) {
+            try {
+                SwingUtilities.invokeAndWait(new Runnable() {
+                    @Override
+                    public void run() {
+                        runTest(exceptionType);
+                    }
+                });
+            } catch (InterruptedException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (printError == null) {
+            throw new RuntimeException("No exception was thrown.");
+        } else if (!(printError instanceof PrinterException)) {
+            throw new RuntimeException("Unexpected exception was thrown.");
+        }
+        System.out.println("Test passed.");
+    }
+
+    private void runTest(final TestExceptionType exceptionType) {
+        PrinterJob job = PrinterJob.getPrinterJob();
+        if (job.getPrintService() == null) {
+            System.out.println("No printers are available.");
+            return;
+        }
+
+        job.setPrintable(new Printable() {
+            @Override
+            public int print(Graphics graphics, PageFormat pageFormat,
+                    int pageIndex) throws PrinterException {
+                if (pageIndex > 1) {
+                    return NO_SUCH_PAGE;
+                }
+                if (exceptionType == TestExceptionType.PE) {
+                    throw new PrinterException(
+                        "Exception from 'Printable.print'.");
+                } else if (exceptionType == TestExceptionType.RE) {
+                    throw new RuntimeException(
+                        "Exception from 'Printable.print'.");
+                }
+                return PAGE_EXISTS;
+            }
+        });
+
+        try {
+            job.print();
+        } catch (Throwable t) {
+            printError = t;
+
+            System.out.println("'PrinterJob.print' threw the exception:");
+            t.printStackTrace(System.out);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

this pull request contains a backport of commit c0b4407d from the openjdk/jdk repository.

The commit being backported was authored by Anton Litvinov on 14 Jun 2021 and was reviewed by Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262731](https://bugs.openjdk.java.net/browse/JDK-8262731): [macOS] Exception from "Printable.print" is swallowed during "PrinterJob.print"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/4.diff">https://git.openjdk.java.net/jdk17u/pull/4.diff</a>

</details>
