### PR TITLE
8268427: Improve AlgorithmConstraints:checkAlgorithm performance

### DIFF
--- a/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
@@ -32,6 +32,7 @@ import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.TreeSet;
 import java.util.List;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public abstract class AbstractAlgorithmConstraints
     }
 
     // Get algorithm constraints from the specified security property.
-    static List<String> getAlgorithms(String propertyName) {
+    static Set<String> getAlgorithms(String propertyName) {
         @SuppressWarnings("removal")
         String property = AccessController.doPrivileged(
                 new PrivilegedAction<String>() {
@@ -73,38 +74,30 @@ public abstract class AbstractAlgorithmConstraints
 
         // map the disabled algorithms
         if (algorithmsInProperty == null) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
-        return new ArrayList<>(Arrays.asList(algorithmsInProperty));
+        Set<String> algorithmsInPropertySet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        algorithmsInPropertySet.addAll(Arrays.asList(algorithmsInProperty));
+        return algorithmsInPropertySet;
     }
 
-    static boolean checkAlgorithm(List<String> algorithms, String algorithm,
+    static boolean checkAlgorithm(Set<String> algorithms, String algorithm,
             AlgorithmDecomposer decomposer) {
         if (algorithm == null || algorithm.isEmpty()) {
             throw new IllegalArgumentException("No algorithm name specified");
         }
 
-        Set<String> elements = null;
-        for (String item : algorithms) {
-            if (item == null || item.isEmpty()) {
-                continue;
-            }
+        if (algorithms.contains(algorithm)) {
+            return false;
+        }
 
-            // check the full name
-            if (item.equalsIgnoreCase(algorithm)) {
+        // decompose the algorithm into sub-elements
+        Set<String> elements = decomposer.decompose(algorithm);
+
+        // check the element of the elements
+        for (String element : elements) {
+            if (algorithms.contains(element)) {
                 return false;
-            }
-
-            // decompose the algorithm into sub-elements
-            if (elements == null) {
-                elements = decomposer.decompose(algorithm);
-            }
-
-            // check the items of the algorithm
-            for (String element : elements) {
-                if (item.equalsIgnoreCase(element)) {
-                    return false;
-                }
             }
         }
 

--- a/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
@@ -40,7 +40,7 @@ public class LegacyAlgorithmConstraints extends AbstractAlgorithmConstraints {
     public static final String PROPERTY_TLS_LEGACY_ALGS =
             "jdk.tls.legacyAlgorithms";
 
-    private final List<String> legacyAlgorithms;
+    private final Set<String> legacyAlgorithms;
 
     public LegacyAlgorithmConstraints(String propertyName,
             AlgorithmDecomposer decomposer) {

--- a/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
+++ b/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.security;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import sun.security.util.DisabledAlgorithmConstraints;
+
+import java.security.AlgorithmConstraints;
+import java.security.CryptoPrimitive;
+import java.util.concurrent.TimeUnit;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static sun.security.util.DisabledAlgorithmConstraints.PROPERTY_TLS_DISABLED_ALGS;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@State(Scope.Thread)
+public class AlgorithmConstraintsPermits {
+
+    AlgorithmConstraints tlsDisabledAlgConstraints;
+    Set<CryptoPrimitive> primitives = EnumSet.of(CryptoPrimitive.KEY_AGREEMENT);
+
+    @Param({"SSLv3", "DES", "NULL", "TLS1.3"})
+    String algorithm;
+
+    @Setup
+    public void setup() {
+        tlsDisabledAlgConstraints = new DisabledAlgorithmConstraints(PROPERTY_TLS_DISABLED_ALGS);
+    }
+
+    @Benchmark
+    public boolean permits() {
+        return tlsDisabledAlgConstraints.permits(primitives, algorithm, null);
+    }
+}
+


### PR DESCRIPTION
`sun.security.util.AbstractAlgorithmConstraints.checkAlgorithm()` uses linear search to check if an algorithm has been disabled. Its execution time is high in the most common case: a checked algorithm is not disabled.

This backport replaces the list with an ordered set. This improves AbstractAlgorithmConstraints.checkAlgorithm() performance, especially for permitted algorithms.

The patch applies cleanly. Tier1 and tier2 tests pass with the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268427](https://bugs.openjdk.java.net/browse/JDK-8268427): Improve AlgorithmConstraints:checkAlgorithm performance


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/10.diff">https://git.openjdk.java.net/jdk17u/pull/10.diff</a>

</details>
