### PR TITLE
8271276: C2: Wrong JVM state used for receiver null check

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -736,13 +736,6 @@ void CallGenerator::do_late_inline_helper() {
       C->set_default_node_notes(entry_nn);
     }
 
-    // Virtual call involves a receiver null check which can be made implicit.
-    if (is_virtual_late_inline()) {
-      GraphKit kit(jvms);
-      kit.null_check_receiver();
-      jvms = kit.transfer_exceptions_into_jvms();
-    }
-
     // Now perform the inlining using the synthesized JVMState
     JVMState* new_jvms = inline_cg()->generate(jvms);
     if (new_jvms == NULL)  return;  // no change

--- a/test/hotspot/jtreg/compiler/inlining/LateInlineVirtualNullReceiverCheck.java
+++ b/test/hotspot/jtreg/compiler/inlining/LateInlineVirtualNullReceiverCheck.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8271276
+ * @run main/othervm -Xbatch compiler.inlining.LateInlineVirtualNullReceiverCheck
+ */
+package compiler.inlining;
+
+import java.util.regex.Pattern;
+
+public class LateInlineVirtualNullReceiverCheck {
+    static final Pattern pattern = Pattern.compile("");
+
+    public static void test(String s) {
+        pattern.matcher(s);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; ++i) {
+            try {
+                test(null);
+            } catch (NullPointerException npe) {
+                // ignore
+            }
+        }
+        System.out.println("TEST PASSED");
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8271276](https://bugs.openjdk.java.net/browse/JDK-8271276). Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271276](https://bugs.openjdk.java.net/browse/JDK-8271276): C2: Wrong JVM state used for receiver null check


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/19.diff">https://git.openjdk.java.net/jdk17u/pull/19.diff</a>

</details>
