### PR TITLE
8272124: Cgroup v1 initialization causes NullPointerException when cgroup path contains colon

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -194,9 +194,10 @@ public class CgroupSubsystemFactory {
             if (isCgroupsV2) {
                 action = (tokens -> setCgroupV2Path(infos, tokens));
             }
-            selfCgroupLines.map(line -> line.split(":"))
-                     .filter(tokens -> (tokens.length >= 3))
-                     .forEach(action);
+            // The limit value of 3 is because /proc/self/cgroup contains three
+            // colon-separated tokens per line. The last token, cgroup path, might
+            // contain a ':'.
+            selfCgroupLines.map(line -> line.split(":", 3)).forEach(action);
         }
 
         CgroupTypeResult result = new CgroupTypeResult(isCgroupsV2,


### PR DESCRIPTION
The patch for this backport applied cleanly and was tested by running the accompanying test and regression tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows. and Mach5 tiers 3-5 on Linux x64 and Linux aarch64.
Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272124](https://bugs.openjdk.java.net/browse/JDK-8272124): Cgroup v1 initialization causes NullPointerException when cgroup path contains colon


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/22.diff">https://git.openjdk.java.net/jdk17u/pull/22.diff</a>

</details>
