### PR TITLE
8270137: Kerberos Credential Retrieval from Cache not Working in Cross-Realm Setup

### DIFF
--- a/test/jdk/sun/security/krb5/auto/ReferralsTest.java
+++ b/test/jdk/sun/security/krb5/auto/ReferralsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Red Hat, Inc.
+ * Copyright (c) 2019, 2021, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,6 +287,16 @@ public class ReferralsTest {
      * on different realms.
      */
     private static void testImpersonation() throws Exception {
+        testImpersonationSingle();
+
+        // Try a second time to force the use of the Referrals Cache.
+        // During this execution, the referral ticket from RABBIT.HOLE
+        // to DEV.RABBIT.HOLE (upon the initial S4U2Self message) will
+        // be obtained from the Cache.
+        testImpersonationSingle();
+    }
+
+    private static void testImpersonationSingle() throws Exception {
         Context s = Context.fromUserPass(serviceKDC2Name, password, true);
         s.startAsServer(GSSUtil.GSS_KRB5_MECH_OID);
         GSSName impName = s.impersonate(userKDC1Name).cred().getName();
@@ -306,6 +316,16 @@ public class ReferralsTest {
      * because the server and the backend are on different realms.
      */
     private static void testDelegationWithReferrals() throws Exception {
+        testDelegationWithReferralsSingle();
+
+        // Try a second time to force the use of the Referrals Cache.
+        // During this execution, the referral ticket from RABBIT.HOLE
+        // to DEV.RABBIT.HOLE (upon the initial S4U2Proxy message) will
+        // be obtained from the Cache.
+        testDelegationWithReferralsSingle();
+    }
+
+    private static void testDelegationWithReferralsSingle() throws Exception {
         Context c = Context.fromUserPass(userKDC1Name, password, false);
         c.startAsClient(serviceName, GSSUtil.GSS_KRB5_MECH_OID);
         Context s = Context.fromUserPass(serviceKDC2Name, password, true);


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8270137 from the openjdk/jdk repository.

The commit being backported was authored by Martin Balao on 10 Aug 2021 and was reviewed by Weijun Wang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270137](https://bugs.openjdk.java.net/browse/JDK-8270137): Kerberos Credential Retrieval from Cache not Working in Cross-Realm Setup


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/33.diff">https://git.openjdk.java.net/jdk17u/pull/33.diff</a>

</details>
