### PR TITLE
8272708: [Test]: Cleanup: test/jdk/security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java no longer needs ocspEnabled

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java
@@ -57,18 +57,15 @@ public class BuypassCA {
 
         ValidatePathWithParams pathValidator = new ValidatePathWithParams(null);
 
-        boolean ocspEnabled = true;
-
         if (args.length >= 1 && "CRL".equalsIgnoreCase(args[0])) {
             pathValidator.enableCRLCheck();
-            ocspEnabled = false;
         } else {
             // OCSP check by default
             pathValidator.enableOCSPCheck();
         }
 
         new BuypassClass2().runTest(pathValidator);
-        new BuypassClass3().runTest(pathValidator, ocspEnabled);
+        new BuypassClass3().runTest(pathValidator);
     }
 }
 
@@ -320,8 +317,7 @@ class BuypassClass3 {
             "BJmiWd5uUxev0nVw0saqvlo4yAEBq4rI/DieKcQI4qEI8myzoS0R0azMfLM=\n" +
             "-----END CERTIFICATE-----";
 
-    public void runTest(ValidatePathWithParams pathValidator, boolean ocspEnabled)
-            throws Exception {
+    public void runTest(ValidatePathWithParams pathValidator) throws Exception {
         // Validate valid
         pathValidator.validate(new String[]{VALID_CLASS_3, INT_CLASS_3},
                 ValidatePathWithParams.Status.GOOD, null, System.out);


### PR DESCRIPTION
This is a clean, straight backport of the following bug:

8272708: [Test]: Cleanup: test/jdk/security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java no longer needs ocspEnabled

Patch applies clean, and test passes post patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272708](https://bugs.openjdk.java.net/browse/JDK-8272708): [Test]: Cleanup: test/jdk/security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java no longer needs ocspEnabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/34.diff">https://git.openjdk.java.net/jdk17u/pull/34.diff</a>

</details>
