### PR TITLE
8269280: (bf) Replace StringBuffer in *Buffer.toString()

### DIFF
--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -1666,16 +1666,11 @@ public abstract class $Type$Buffer
      * @return  A summary string
      */
     public String toString() {
-        StringBuffer sb = new StringBuffer();
-        sb.append(getClass().getName());
-        sb.append("[pos=");
-        sb.append(position());
-        sb.append(" lim=");
-        sb.append(limit());
-        sb.append(" cap=");
-        sb.append(capacity());
-        sb.append("]");
-        return sb.toString();
+        return getClass().getName()
+                 + "[pos=" + position()
+                 + " lim=" + limit()
+                 + " cap=" + capacity()
+                 + "]";
     }
 
 #end[!char]

--- a/test/jdk/java/nio/Buffer/Basic-X.java.template
+++ b/test/jdk/java/nio/Buffer/Basic-X.java.template
@@ -1134,6 +1134,26 @@ public class Basic$Type$
 #end[byte]
     }
 
+    public static void testToString() {
+        final int cap = 10;
+
+#if[byte]
+        $Type$Buffer direct1 = $Type$Buffer.allocateDirect(cap);
+        if (!direct1.toString().equals(Basic.toString(direct1))) {
+           fail("Direct buffer toString is incorrect: "
+                  + direct1.toString() + " vs " + Basic.toString(direct1));
+        }
+#end[byte]
+
+#if[!char]
+        $Type$Buffer nondirect1 = $Type$Buffer.allocate(cap);
+        if (!nondirect1.toString().equals(Basic.toString(nondirect1))) {
+           fail("Heap buffer toString is incorrect: "
+                  + nondirect1.toString() + " vs " + Basic.toString(nondirect1));
+        }
+#end[!char]
+    }
+
     public static void test() {
         testAllocate();
         test(0, $Type$Buffer.allocate(7 * 1024), false);
@@ -1155,6 +1175,8 @@ public class Basic$Type$
 #else[byte]
         putBuffer();
 #end[byte]
+
+        testToString();
     }
 
 }

--- a/test/jdk/java/nio/Buffer/BasicByte.java
+++ b/test/jdk/java/nio/Buffer/BasicByte.java
@@ -1134,6 +1134,26 @@ public class BasicByte
 
     }
 
+    public static void testToString() {
+        final int cap = 10;
+
+
+        ByteBuffer direct1 = ByteBuffer.allocateDirect(cap);
+        if (!direct1.toString().equals(Basic.toString(direct1))) {
+           fail("Direct buffer toString is incorrect: "
+                  + direct1.toString() + " vs " + Basic.toString(direct1));
+        }
+
+
+
+        ByteBuffer nondirect1 = ByteBuffer.allocate(cap);
+        if (!nondirect1.toString().equals(Basic.toString(nondirect1))) {
+           fail("Heap buffer toString is incorrect: "
+                  + nondirect1.toString() + " vs " + Basic.toString(nondirect1));
+        }
+
+    }
+
     public static void test() {
         testAllocate();
         test(0, ByteBuffer.allocate(7 * 1024), false);
@@ -1155,6 +1175,8 @@ public class BasicByte
 
 
 
+
+        testToString();
     }
 
 }

--- a/test/jdk/java/nio/Buffer/BasicChar.java
+++ b/test/jdk/java/nio/Buffer/BasicChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,17 @@
 
 // -- This file was mechanically generated: Do not edit! -- //
 
+
+
+
+
 import java.nio.*;
+
+
+
+
+
+
 
 
 public class BasicChar
@@ -220,6 +230,73 @@ public class BasicChar
         if (b.isReadOnly() != slice.isReadOnly())
             fail("Lost read-only", slice);
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1057,6 +1134,26 @@ public class BasicChar
 
     }
 
+    public static void testToString() {
+        final int cap = 10;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    }
+
     public static void test() {
         testAllocate();
         test(0, CharBuffer.allocate(7 * 1024), false);
@@ -1078,6 +1175,8 @@ public class BasicChar
 
         putBuffer();
 
+
+        testToString();
     }
 
 }

--- a/test/jdk/java/nio/Buffer/BasicDouble.java
+++ b/test/jdk/java/nio/Buffer/BasicDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,17 @@
 
 // -- This file was mechanically generated: Do not edit! -- //
 
+
+
+
+
 import java.nio.*;
+
+
+
+
+
+
 
 
 public class BasicDouble
@@ -220,6 +230,73 @@ public class BasicDouble
         if (b.isReadOnly() != slice.isReadOnly())
             fail("Lost read-only", slice);
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1057,6 +1134,26 @@ public class BasicDouble
 
     }
 
+    public static void testToString() {
+        final int cap = 10;
+
+
+
+
+
+
+
+
+
+
+        DoubleBuffer nondirect1 = DoubleBuffer.allocate(cap);
+        if (!nondirect1.toString().equals(Basic.toString(nondirect1))) {
+           fail("Heap buffer toString is incorrect: "
+                  + nondirect1.toString() + " vs " + Basic.toString(nondirect1));
+        }
+
+    }
+
     public static void test() {
         testAllocate();
         test(0, DoubleBuffer.allocate(7 * 1024), false);
@@ -1078,6 +1175,8 @@ public class BasicDouble
 
         putBuffer();
 
+
+        testToString();
     }
 
 }

--- a/test/jdk/java/nio/Buffer/BasicFloat.java
+++ b/test/jdk/java/nio/Buffer/BasicFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,17 @@
 
 // -- This file was mechanically generated: Do not edit! -- //
 
+
+
+
+
 import java.nio.*;
+
+
+
+
+
+
 
 
 public class BasicFloat
@@ -220,6 +230,73 @@ public class BasicFloat
         if (b.isReadOnly() != slice.isReadOnly())
             fail("Lost read-only", slice);
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1057,6 +1134,26 @@ public class BasicFloat
 
     }
 
+    public static void testToString() {
+        final int cap = 10;
+
+
+
+
+
+
+
+
+
+
+        FloatBuffer nondirect1 = FloatBuffer.allocate(cap);
+        if (!nondirect1.toString().equals(Basic.toString(nondirect1))) {
+           fail("Heap buffer toString is incorrect: "
+                  + nondirect1.toString() + " vs " + Basic.toString(nondirect1));
+        }
+
+    }
+
     public static void test() {
         testAllocate();
         test(0, FloatBuffer.allocate(7 * 1024), false);
@@ -1078,6 +1175,8 @@ public class BasicFloat
 
         putBuffer();
 
+
+        testToString();
     }
 
 }

--- a/test/jdk/java/nio/Buffer/BasicInt.java
+++ b/test/jdk/java/nio/Buffer/BasicInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,17 @@
 
 // -- This file was mechanically generated: Do not edit! -- //
 
+
+
+
+
 import java.nio.*;
+
+
+
+
+
+
 
 
 public class BasicInt
@@ -220,6 +230,73 @@ public class BasicInt
         if (b.isReadOnly() != slice.isReadOnly())
             fail("Lost read-only", slice);
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1057,6 +1134,26 @@ public class BasicInt
 
     }
 
+    public static void testToString() {
+        final int cap = 10;
+
+
+
+
+
+
+
+
+
+
+        IntBuffer nondirect1 = IntBuffer.allocate(cap);
+        if (!nondirect1.toString().equals(Basic.toString(nondirect1))) {
+           fail("Heap buffer toString is incorrect: "
+                  + nondirect1.toString() + " vs " + Basic.toString(nondirect1));
+        }
+
+    }
+
     public static void test() {
         testAllocate();
         test(0, IntBuffer.allocate(7 * 1024), false);
@@ -1078,6 +1175,8 @@ public class BasicInt
 
         putBuffer();
 
+
+        testToString();
     }
 
 }

--- a/test/jdk/java/nio/Buffer/BasicLong.java
+++ b/test/jdk/java/nio/Buffer/BasicLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,17 @@
 
 // -- This file was mechanically generated: Do not edit! -- //
 
+
+
+
+
 import java.nio.*;
+
+
+
+
+
+
 
 
 public class BasicLong
@@ -220,6 +230,73 @@ public class BasicLong
         if (b.isReadOnly() != slice.isReadOnly())
             fail("Lost read-only", slice);
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1057,6 +1134,26 @@ public class BasicLong
 
     }
 
+    public static void testToString() {
+        final int cap = 10;
+
+
+
+
+
+
+
+
+
+
+        LongBuffer nondirect1 = LongBuffer.allocate(cap);
+        if (!nondirect1.toString().equals(Basic.toString(nondirect1))) {
+           fail("Heap buffer toString is incorrect: "
+                  + nondirect1.toString() + " vs " + Basic.toString(nondirect1));
+        }
+
+    }
+
     public static void test() {
         testAllocate();
         test(0, LongBuffer.allocate(7 * 1024), false);
@@ -1078,6 +1175,8 @@ public class BasicLong
 
         putBuffer();
 
+
+        testToString();
     }
 
 }

--- a/test/jdk/java/nio/Buffer/BasicShort.java
+++ b/test/jdk/java/nio/Buffer/BasicShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,17 @@
 
 // -- This file was mechanically generated: Do not edit! -- //
 
+
+
+
+
 import java.nio.*;
+
+
+
+
+
+
 
 
 public class BasicShort
@@ -220,6 +230,73 @@ public class BasicShort
         if (b.isReadOnly() != slice.isReadOnly())
             fail("Lost read-only", slice);
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1057,6 +1134,26 @@ public class BasicShort
 
     }
 
+    public static void testToString() {
+        final int cap = 10;
+
+
+
+
+
+
+
+
+
+
+        ShortBuffer nondirect1 = ShortBuffer.allocate(cap);
+        if (!nondirect1.toString().equals(Basic.toString(nondirect1))) {
+           fail("Heap buffer toString is incorrect: "
+                  + nondirect1.toString() + " vs " + Basic.toString(nondirect1));
+        }
+
+    }
+
     public static void test() {
         testAllocate();
         test(0, ShortBuffer.allocate(7 * 1024), false);
@@ -1078,6 +1175,8 @@ public class BasicShort
 
         putBuffer();
 
+
+        testToString();
     }
 
 }


### PR DESCRIPTION
Clean backport to improve performance in post-BiasedLocking world.

Additional testing: 
 - [x] `java/nio/Buffer` tests are passing
 - [x] Re-generating the test code from the new template yields the same contents

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269280](https://bugs.openjdk.java.net/browse/JDK-8269280): (bf) Replace StringBuffer in *Buffer.toString()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/35.diff">https://git.openjdk.java.net/jdk17u/pull/35.diff</a>

</details>
