### PR TITLE
8270344: Session resumption errors

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ClientHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHello.java
@@ -402,9 +402,6 @@ final class ClientHello {
             // clean up this producer
             chc.handshakeProducers.remove(SSLHandshake.CLIENT_HELLO.id);
 
-            // the max protocol version this client is supporting.
-            ProtocolVersion maxProtocolVersion = chc.maximumActiveProtocol;
-
             // session ID of the ClientHello message
             SessionId sessionId = new SessionId(new byte[0]);
 
@@ -538,14 +535,6 @@ final class ClientHello {
                 if (!session.getProtocolVersion().useTLS13PlusSpec()) {
                     sessionId = session.getSessionId();
                 }
-                if (!maxProtocolVersion.equals(sessionVersion)) {
-                    maxProtocolVersion = sessionVersion;
-
-                    // Update protocol version number in underlying socket and
-                    // handshake output stream, so that the output records
-                    // (at the record layer) have the correct version
-                    chc.setVersion(sessionVersion);
-                }
 
                 // If no new session is allowed, force use of the previous
                 // session ciphersuite, and add the renegotiation SCSV if
@@ -580,7 +569,7 @@ final class ClientHello {
                             "no existing session can be resumed");
                 }
 
-                if (maxProtocolVersion.useTLS13PlusSpec() &&
+                if (chc.maximumActiveProtocol.useTLS13PlusSpec() &&
                         SSLConfiguration.useCompatibilityMode) {
                     // In compatibility mode, the TLS 1.3 legacy_session_id
                     // field MUST be non-empty, so a client not offering a
@@ -623,7 +612,7 @@ final class ClientHello {
             }
 
             // Create the handshake message.
-            ProtocolVersion clientHelloVersion = maxProtocolVersion;
+            ProtocolVersion clientHelloVersion = chc.maximumActiveProtocol;
             if (clientHelloVersion.useTLS13PlusSpec()) {
                 // In (D)TLS 1.3, the client indicates its version preferences
                 // in the "supported_versions" extension and the client_version

--- a/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
@@ -534,15 +534,6 @@ abstract class HandshakeContext implements ConnectionContext {
         return activeProtocols.contains(protocolVersion);
     }
 
-    /**
-     * Set the active protocol version and propagate it to the SSLSocket
-     * and our handshake streams. Called from ClientHandshaker
-     * and ServerHandshaker with the negotiated protocol version.
-     */
-    void setVersion(ProtocolVersion protocolVersion) {
-        this.conContext.protocolVersion = protocolVersion;
-    }
-
     private static boolean isActivatable(CipherSuite suite,
             AlgorithmConstraints algorithmConstraints,
             Map<NamedGroupSpec, Boolean> cachedStatus) {

--- a/src/java.base/share/classes/sun/security/ssl/TransportContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/TransportContext.java
@@ -81,7 +81,6 @@ final class TransportContext implements ConnectionContext {
     boolean                         needHandshakeFinishedStatus = false;
     boolean                         hasDelegatedFinished = false;
 
-
     // negotiated security parameters
     SSLSessionImpl                  conSession;
     ProtocolVersion                 protocolVersion;

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/InvalidateSession.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/InvalidateSession.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8270344
+ * @library /test/lib /javax/net/ssl/templates
+ * @summary Session resumption errors
+ * @run main/othervm InvalidateSession
+ */
+
+import javax.net.*;
+import javax.net.ssl.*;
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+import jdk.test.lib.security.SecurityUtils;
+
+public class InvalidateSession implements SSLContextTemplate {
+
+    static ServerSocketFactory serverSsf = null;
+    static SSLSocketFactory clientSsf = null;
+
+    static Server server;
+    static SSLSession cacheSession;
+    static final String[] CLIENT_VERSIONS = {"TLSv1", "TLSv1.1", "TLSv1.2"};
+
+    public static void main(String args[]) throws Exception {
+        // drop the supported_versions extension to force test to use the legacy
+        // TLS protocol version field during handshakes
+        System.setProperty("jdk.tls.client.disableExtensions", "supported_versions");
+        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1");
+
+        InvalidateSession test = new InvalidateSession();
+        test.sessionTest();
+        server.go = false;
+    }
+
+    /**
+     * 3 test iterations
+     * 1) Server configured with TLSv1, client with TLSv1, v1.1, v1.2
+     * - Handshake should succeed
+     * - Session "A" established
+     * 2) 2nd iteration, server configured with TLSv1.2 only
+     * - Connection should succeed but with a new session due to TLS protocol version change
+     * - Session "A" should be invalidated
+     * - Session "B" is created
+     * 3) 3rd iteration, same server/client config
+     * - Session "B" should continue to be in use
+     */
+    private void sessionTest() throws Exception {
+        serverSsf = createServerSSLContext().getServerSocketFactory();
+        clientSsf = createClientSSLContext().getSocketFactory();
+        server = startServer();
+        while (!server.started) {
+            Thread.yield();
+        }
+
+        for (int i = 1; i <= 3; i++) {
+            clientConnect(i);
+            Thread.sleep(1000);
+        }
+    }
+
+    public void clientConnect(int testIterationCount) throws Exception {
+        System.out.printf("Connecting to: localhost: %s, iteration count %d%n",
+                "localhost:" + server.port, testIterationCount);
+        SSLSocket sslSocket = (SSLSocket) clientSsf.createSocket("localhost", server.port);
+        sslSocket.setEnabledProtocols(CLIENT_VERSIONS);
+        sslSocket.startHandshake();
+
+        System.out.println("Got session: " + sslSocket.getSession());
+
+        if (testIterationCount == 2 && Objects.equals(cacheSession, sslSocket.getSession())) {
+            throw new RuntimeException("Same session should not have resumed");
+        }
+        if (testIterationCount == 3 && !Objects.equals(cacheSession, sslSocket.getSession())) {
+            throw new RuntimeException("Same session should have resumed");
+        }
+
+        cacheSession = sslSocket.getSession();
+
+        try (
+        ObjectOutputStream oos = new ObjectOutputStream(sslSocket.getOutputStream());
+        ObjectInputStream ois = new ObjectInputStream(sslSocket.getInputStream())) {
+            oos.writeObject("Hello");
+            String serverMsg = (String) ois.readObject();
+            System.out.println("Server message : " + serverMsg);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            sslSocket.close();
+        }
+    }
+
+    private static Server startServer() {
+        Server server = new Server();
+        new Thread(server).start();
+        return server;
+    }
+
+    private static class Server implements Runnable {
+        public volatile boolean go = true;
+        public volatile int port = 0;
+        public volatile boolean started = false;
+
+        @Override
+        public void run() {
+            try {
+                SSLServerSocket ssock = (SSLServerSocket)
+                        serverSsf.createServerSocket(0);
+                this.port = ssock.getLocalPort();
+                ssock.setEnabledProtocols(new String[]{"TLSv1"});
+                started = true;
+                while (go) {
+                    try {
+                        System.out.println("Waiting for connection");
+                        Socket sock = ssock.accept();
+                        // now flip server to TLSv1.2 mode for successive connections
+                        ssock.setEnabledProtocols(new String[]{"TLSv1.2"});
+                        try (
+                        ObjectInputStream ois = new ObjectInputStream(sock.getInputStream());
+                        ObjectOutputStream oos = new ObjectOutputStream(sock.getOutputStream())) {
+                            String recv = (String) ois.readObject();
+                            oos.writeObject("Received: " + recv);
+                        } catch (SSLHandshakeException she) {
+                            System.out.println("Server caught :" + she);
+                        } finally {
+                            sock.close();
+                        }
+                    } catch (Exception ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Clean backport to JDK 17 Updates

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270344](https://bugs.openjdk.java.net/browse/JDK-8270344): Session resumption errors


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/39.diff">https://git.openjdk.java.net/jdk17u/pull/39.diff</a>

</details>
