### PR TITLE
8272581: sun/security/pkcs11/Provider/MultipleLogins.sh fails after JDK-8266182

### DIFF
--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -44,7 +44,7 @@ import jdk.test.lib.Asserts;
 import jdk.test.lib.SecurityTools;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.artifacts.OpensslArtifactFetcher;
+import jdk.test.lib.security.OpensslArtifactFetcher;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package jdk.test.lib.artifacts;
+package jdk.test.lib.security;
 
 import java.io.File;
 


### PR DESCRIPTION
Test Result - https://mach5.us.oracle.com/mdash/jobs/akolarku-jdk17u-cpu-20210825-0713-24028774

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272581](https://bugs.openjdk.java.net/browse/JDK-8272581): sun/security/pkcs11/Provider/MultipleLogins.sh fails after JDK-8266182


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/43.diff">https://git.openjdk.java.net/jdk17u/pull/43.diff</a>

</details>
