### PR TITLE
8269993: [Test]: java/net/httpclient/DigestEchoClientSSL.java contains redundant @run tags

### DIFF
--- a/test/jdk/java/net/httpclient/DigestEchoClientSSL.java
+++ b/test/jdk/java/net/httpclient/DigestEchoClientSSL.java
@@ -39,12 +39,6 @@
  * @run main/othervm/timeout=300
  *          DigestEchoClientSSL SSL
  * @run main/othervm/timeout=300
- *          DigestEchoClientSSL SSL
- * @run main/othervm/timeout=300
- *          -Djdk.http.auth.proxying.disabledSchemes=
- *          -Djdk.http.auth.tunneling.disabledSchemes=
- *          DigestEchoClientSSL SSL PROXY
- * @run main/othervm/timeout=300
  *          -Djdk.http.auth.proxying.disabledSchemes=
  *          -Djdk.http.auth.tunneling.disabledSchemes=
  *          DigestEchoClientSSL SSL PROXY


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8269993 from the openjdk/jdk repository.

The commit being backported was authored by Thejasvi Voniadka on 8 Jul 2021 and was reviewed by Daniel Fuchs and Vyom Tewari.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269993](https://bugs.openjdk.java.net/browse/JDK-8269993): [Test]: java/net/httpclient/DigestEchoClientSSL.java contains redundant @run tags


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/44.diff">https://git.openjdk.java.net/jdk17u/pull/44.diff</a>

</details>
