### PR TITLE
8271121: ZGC: stack overflow (segv) when -Xlog:gc+start=debug

### DIFF
--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -760,8 +760,10 @@ ZStatCriticalPhase::ZStatCriticalPhase(const char* name, bool verbose) :
     _verbose(verbose) {}
 
 void ZStatCriticalPhase::register_start(const Ticks& start) const {
-  LogTarget(Debug, gc, start) log;
-  log_start(log, true /* thread */);
+  // This is called from sensitive contexts, for example before an allocation stall
+  // has been resolved. This means we must not access any oops in here since that
+  // could lead to infinite recursion. Without access to the thread name we can't
+  // really log anything useful here.
 }
 
 void ZStatCriticalPhase::register_end(const Ticks& start, const Ticks& end) const {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [18dd4d46](https://github.com/openjdk/jdk/commit/18dd4d469d120276d05e74607d780f01056f1a8b) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Per Liden on 5 Aug 2021 and was reviewed by Albert Mingkun Yang and Erik Österlund.

Thanks!

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271121](https://bugs.openjdk.java.net/browse/JDK-8271121): ZGC: stack overflow (segv) when -Xlog:gc+start=debug


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/53.diff">https://git.openjdk.java.net/jdk17u/pull/53.diff</a>

</details>
