### PR TITLE
8272973: Incorrect compile command used by TestIllegalArrayCopyBeforeInfiniteLoop

### DIFF
--- a/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
@@ -27,7 +27,7 @@
  * @requires vm.compiler2.enabled
  * @summary ArrayCopy with negative index before infinite loop
  * @run main/othervm -Xbatch -XX:-TieredCompilation
- *                   -XX:CompileCommand=compileonly,"*TestIllegalArrayCopyBeforeInfiniteLoop::foo"
+ *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop::foo
  *                   compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop
  */
 
@@ -38,7 +38,7 @@ import java.util.Arrays;
 public class TestIllegalArrayCopyBeforeInfiniteLoop {
     private static char src[] = new char[10];
     private static int count = 0;
-    private static final int iter = 10_000;
+    private static final int iter = 20_000;
 
     public static void main(String[] args) throws Exception {
         for (int i = 0; i < iter; ++i) {


### PR DESCRIPTION
Clean backport to fix the test. 

Additional testing:
 - [x] Eyeballed test output to see that `CompilerCommand` error is gone

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272973](https://bugs.openjdk.java.net/browse/JDK-8272973): Incorrect compile command used by TestIllegalArrayCopyBeforeInfiniteLoop


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/55.diff">https://git.openjdk.java.net/jdk17u/pull/55.diff</a>

</details>
