### PR TITLE
8270171: Shenandoah: Cleanup TestStringDedup and TestStringDedupStress tests

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestStringDedup.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringDedup.java
@@ -49,7 +49,6 @@
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @library /test/lib
- * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
  *
@@ -72,7 +71,6 @@
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @library /test/lib
- * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
  *
@@ -89,11 +87,8 @@ import java.lang.reflect.*;
 import java.util.*;
 import jdk.test.lib.Utils;
 
-import sun.misc.*;
-
 public class TestStringDedup {
     private static Field valueField;
-    private static Unsafe unsafe;
 
     private static final int UniqueStrings = 20;
     // How many GC cycles are needed to complete deduplication.
@@ -101,10 +96,6 @@ public class TestStringDedup {
 
     static {
         try {
-            Field field = Unsafe.class.getDeclaredField("theUnsafe");
-            field.setAccessible(true);
-            unsafe = (Unsafe) field.get(null);
-
             valueField = String.class.getDeclaredField("value");
             valueField.setAccessible(true);
         } catch (Exception e) {

--- a/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @library /test/lib
- * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
  *
@@ -49,7 +48,6 @@
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @library /test/lib
- * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
  *
@@ -80,7 +78,6 @@
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @library /test/lib
- * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
  *
@@ -111,11 +108,8 @@ import java.lang.reflect.*;
 import java.util.*;
 import jdk.test.lib.Utils;
 
-import sun.misc.*;
-
 public class TestStringDedupStress {
     private static Field valueField;
-    private static Unsafe unsafe;
 
     private static final int TARGET_STRINGS = Integer.getInteger("targetStrings", 2_500_000);
     private static final long MAX_REWRITE_GC_CYCLES = 6;
@@ -125,10 +119,6 @@ public class TestStringDedupStress {
 
     static {
         try {
-            Field field = Unsafe.class.getDeclaredField("theUnsafe");
-            field.setAccessible(true);
-            unsafe = (Unsafe) field.get(null);
-
             valueField = String.class.getDeclaredField("value");
             valueField.setAccessible(true);
         } catch (Exception e) {


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing: 
  - [x] Affected test still pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270171](https://bugs.openjdk.java.net/browse/JDK-8270171): Shenandoah: Cleanup TestStringDedup and TestStringDedupStress tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/58.diff">https://git.openjdk.java.net/jdk17u/pull/58.diff</a>

</details>
