### PR TITLE
8271560: sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java still fails due to "An established connection was aborted by the software in your host machine"

### DIFF
--- a/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
@@ -32,8 +32,10 @@
  * @run main/othervm -Djdk.tls.ephemeralDHKeySize=legacy LegacyDHEKeyExchange
  */
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
+import java.net.SocketException;
 import java.util.concurrent.CountDownLatch;
 
 public class LegacyDHEKeyExchange extends SSLSocketTemplate{
@@ -53,6 +55,10 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
                 throw she;
             }
             System.out.println("Expected exception thrown in server");
+        } catch (SSLException | SocketException se) {
+            // The client side may have closed the socket.
+            System.out.println("Server exception:");
+            se.printStackTrace(System.out);
         } finally {
             connDoneLatch.countDown();
             connDoneLatch.await();
@@ -75,6 +81,10 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
                 throw she;
             }
             System.out.println("Expected exception thrown in client");
+        } catch (SSLException | SocketException se) {
+            // The server side may have closed the socket.
+            System.out.println("Client exception:");
+            se.printStackTrace(System.out);
         } finally {
             connDoneLatch.countDown();
             connDoneLatch.await();


### PR DESCRIPTION
This is a straight, clean backport of:

8271560: sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java still fails due to "An established connection was aborted by the software in your host machine"

The patch applies clean, and the test passes on all platforms post patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271560](https://bugs.openjdk.java.net/browse/JDK-8271560): sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java still fails due to "An established connection was aborted by the software in your host machine"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/59.diff">https://git.openjdk.java.net/jdk17u/pull/59.diff</a>

</details>
