### PR TITLE
8272318: Improve performance of HeapDumpAllTest

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
@@ -21,6 +21,10 @@
  * questions.
  */
 
+import java.io.IOException;
+
+import jdk.test.lib.dcmd.CommandExecutor;
+
 /*
  * @test
  * @summary Test of diagnostic command GC.heap_dump -all=true
@@ -35,6 +39,14 @@ public class HeapDumpAllTest extends HeapDumpTest {
     public HeapDumpAllTest() {
         super();
         heapDumpArgs = "-all=true";
+    }
+
+    @Override
+    public void run(CommandExecutor executor, boolean overwrite) throws IOException {
+        // Trigger gc by hand, so the created heap dump isnt't too large and
+        // takes too long to parse.
+        System.gc();
+        super.run(executor, overwrite);
     }
 
     /* See HeapDumpTest for test cases */


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing: 
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272318](https://bugs.openjdk.java.net/browse/JDK-8272318): Improve performance of HeapDumpAllTest


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/61.diff">https://git.openjdk.java.net/jdk17u/pull/61.diff</a>

</details>
