### PR TITLE
8271862: C2 intrinsic for Reference.refersTo() is often not used

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -69,8 +69,12 @@ public class PhantomReference<T> extends Reference<T> {
      * do reference processing concurrently.
      */
     @Override
+    boolean refersToImpl(T obj) {
+        return refersTo0(obj);
+    }
+
     @IntrinsicCandidate
-    native final boolean refersTo0(Object o);
+    private native boolean refersTo0(Object o);
 
     /**
      * Creates a new phantom reference that refers to the given object and

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -363,13 +363,20 @@ public abstract class Reference<T> {
      * @since 16
      */
     public final boolean refersTo(T obj) {
-        return refersTo0(obj);
+        return refersToImpl(obj);
     }
 
     /* Implementation of refersTo(), overridden for phantom references.
+     * This method exists only to avoid making refersTo0() virtual. Making
+     * refersTo0() virtual has the undesirable effect of C2 often preferring
+     * to call the native implementation over the intrinsic.
      */
+    boolean refersToImpl(T obj) {
+        return refersTo0(obj);
+    }
+
     @IntrinsicCandidate
-    native boolean refersTo0(Object o);
+    private native boolean refersTo0(Object o);
 
     /**
      * Clears this reference object.  Invoking this method will not cause this


### PR DESCRIPTION
Clean backport to make JDK 16 introduced feature more compelling with a workaround.

Additional testing:
 - [x] Linux x86_64 fastdebug, `RefersTo` tests pass

`RefersTo` tests:

```
./test/hotspot/jtreg/gc/TestReferenceRefersTo.java
./test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
./test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
./test/hotspot/jtreg/compiler/intrinsics/TestReferenceRefersTo.java
./test/jdk/java/lang/ref/ReferenceRefersTo.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271862](https://bugs.openjdk.java.net/browse/JDK-8271862): C2 intrinsic for Reference.refersTo() is often not used


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/62.diff">https://git.openjdk.java.net/jdk17u/pull/62.diff</a>

</details>
