### PR TITLE
8272970: Parallelize runtime/InvocationTests/

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -91,7 +91,9 @@ gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 
 runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
 runtime/cds/DeterministicDump.java 8253495 generic-all
-runtime/InvocationTests/invokevirtualTests.java 8271125 generic-all
+runtime/InvocationTests/invokevirtualTests.java#current-int 8271125 generic-all
+runtime/InvocationTests/invokevirtualTests.java#current-comp 8271125 generic-all
+runtime/InvocationTests/invokevirtualTests.java#old-int 8271125 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64

--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
@@ -23,20 +23,41 @@
  */
 
 /*
- * @test
+ * @test id=special
  * @bug 8226956
  * @summary Run invocation tests against C1 compiler
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
- * @compile shared/AbstractGenerator.java shared/AccessCheck.java shared/AccessType.java
- *          shared/Caller.java shared/ExecutorGenerator.java shared/Utils.java
- *          shared/ByteArrayClassLoader.java shared/Checker.java shared/GenericClassGenerator.java
  * @compile invokespecial/Checker.java invokespecial/ClassGenerator.java invokespecial/Generator.java
- *          invokevirtual/Checker.java invokevirtual/ClassGenerator.java invokevirtual/Generator.java
- *          invokeinterface/Checker.java invokeinterface/ClassGenerator.java invokeinterface/Generator.java
  *
- * @run driver/timeout=1800 invocationC1Tests
+ * @run driver/timeout=1800 invocationC1Tests special
+ */
+
+/*
+ * @test id=virtual
+ * @bug 8226956
+ * @summary Run invocation tests against C1 compiler
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokevirtual/Checker.java invokevirtual/ClassGenerator.java invokevirtual/Generator.java
+ *
+ * @run driver/timeout=1800 invocationC1Tests virtual
+ */
+
+/*
+ * @test id=interface
+ * @bug 8226956
+ * @summary Run invocation tests against C1 compiler
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokeinterface/Checker.java invokeinterface/ClassGenerator.java invokeinterface/Generator.java
+ *
+ * @run driver/timeout=1800 invocationC1Tests interface
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -72,11 +93,27 @@ public class invocationC1Tests {
     }
 
     public static void main(String args[]) throws Throwable {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Should provide the test name");
+        }
+        String testName = args[0];
+
         // Get current major class file version and test with it.
         byte klassbuf[] = InMemoryJavaCompiler.compile("blah", "public class blah { }");
         int major_version = klassbuf[6] << 8 | klassbuf[7];
-        runTest("invokespecial.Generator", String.valueOf(major_version));
-        runTest("invokeinterface.Generator", String.valueOf(major_version));
-        runTest("invokevirtual.Generator", String.valueOf(major_version));
+
+        switch (testName) {
+            case "special":
+                runTest("invokespecial.Generator", String.valueOf(major_version));
+                break;
+            case "virtual":
+                runTest("invokevirtual.Generator", String.valueOf(major_version));
+                break;
+            case "interface":
+                runTest("invokeinterface.Generator", String.valueOf(major_version));
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown test name: " + testName);
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationOldCHATests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationOldCHATests.java
@@ -23,19 +23,38 @@
  */
 
 /*
- * @test
+ * @test id=special
  * @summary Run invocation tests with old CHA (-XX:-UseVtableBasedCHA)
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
- * @compile shared/AbstractGenerator.java shared/AccessCheck.java shared/AccessType.java
- *          shared/Caller.java shared/ExecutorGenerator.java shared/Utils.java
- *          shared/ByteArrayClassLoader.java shared/Checker.java shared/GenericClassGenerator.java
  * @compile invokespecial/Checker.java invokespecial/ClassGenerator.java invokespecial/Generator.java
- *          invokevirtual/Checker.java invokevirtual/ClassGenerator.java invokevirtual/Generator.java
- *          invokeinterface/Checker.java invokeinterface/ClassGenerator.java invokeinterface/Generator.java
  *
- * @run driver/timeout=1800 invocationOldCHATests
+ * @run driver/timeout=1800 invocationOldCHATests special
+ */
+
+/*
+ * @test id=virtual
+ * @summary Run invocation tests with old CHA (-XX:-UseVtableBasedCHA)
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokevirtual/Checker.java invokevirtual/ClassGenerator.java invokevirtual/Generator.java
+ *
+ * @run driver/timeout=1800 invocationOldCHATests virtual
+ */
+
+/*
+ * @test id=interface
+ * @summary Run invocation tests with old CHA (-XX:-UseVtableBasedCHA)
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokeinterface/Checker.java invokeinterface/ClassGenerator.java invokeinterface/Generator.java
+ *
+ * @run driver/timeout=1800 invocationOldCHATests interface
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -71,11 +90,27 @@ public class invocationOldCHATests {
     }
 
     public static void main(String args[]) throws Throwable {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Should provide the test name");
+        }
+        String testName = args[0];
+
         // Get current major class file version and test with it.
         byte klassbuf[] = InMemoryJavaCompiler.compile("blah", "public class blah { }");
         int major_version = klassbuf[6] << 8 | klassbuf[7];
-        runTest("invokespecial.Generator", String.valueOf(major_version));
-        runTest("invokeinterface.Generator", String.valueOf(major_version));
-        runTest("invokevirtual.Generator", String.valueOf(major_version));
+
+        switch (testName) {
+            case "special":
+                runTest("invokespecial.Generator", String.valueOf(major_version));
+                break;
+            case "virtual":
+                runTest("invokevirtual.Generator", String.valueOf(major_version));
+                break;
+            case "interface":
+                runTest("invokeinterface.Generator", String.valueOf(major_version));
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown test name: " + testName);
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
@@ -23,19 +23,44 @@
  */
 
 /*
- * @test
+ * @test id=current-int
  * @bug 8224137
  * @summary Run invokeinterface invocation tests
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
- * @compile shared/AbstractGenerator.java shared/AccessCheck.java shared/AccessType.java
- *          shared/Caller.java shared/ExecutorGenerator.java shared/Utils.java
- *          shared/ByteArrayClassLoader.java shared/Checker.java shared/GenericClassGenerator.java
  * @compile invokeinterface/Checker.java invokeinterface/ClassGenerator.java
  *          invokeinterface/Generator.java
  *
- * @run driver/timeout=1800 invokeinterfaceTests
+ * @run driver/timeout=1800 invokeinterfaceTests current-int
+ */
+
+/*
+ * @test id=current-comp
+ * @bug 8224137
+ * @summary Run invokeinterface invocation tests
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokeinterface/Checker.java invokeinterface/ClassGenerator.java
+ *          invokeinterface/Generator.java
+ *
+ * @run driver/timeout=1800 invokeinterfaceTests current-comp
+ */
+
+/*
+ * @test id=old-int
+ * @bug 8224137
+ * @summary Run invokeinterface invocation tests
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokeinterface/Checker.java invokeinterface/ClassGenerator.java
+ *          invokeinterface/Generator.java
+ *
+ * @run driver/timeout=1800 invokeinterfaceTests old-int
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -70,13 +95,28 @@ public class invokeinterfaceTests {
     }
 
     public static void main(String args[]) throws Throwable {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Should provide the test name");
+        }
+        String testName = args[0];
+
         // Get current major class file version and test with it.
         byte klassbuf[] = InMemoryJavaCompiler.compile("blah", "public class blah { }");
         int major_version = klassbuf[6] << 8 | klassbuf[7];
-        runTest(String.valueOf(major_version), "-Xint");
-        runTest(String.valueOf(major_version), "-Xcomp");
 
-        // Test old class file version.
-        runTest("51", "-Xint"); // JDK-7
+        switch (testName) {
+            case "current-int":
+                runTest(String.valueOf(major_version), "-Xint");
+                break;
+            case "current-comp":
+                runTest(String.valueOf(major_version), "-Xcomp");
+                break;
+            case "old-int":
+                // Test old class file version.
+                runTest("51", "-Xint"); // JDK-7
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown test name: " + testName);
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
@@ -23,18 +23,41 @@
  */
 
 /*
- * @test
+ * @test id=current-int
  * @bug 8224137
  * @summary Run invokespecial invocation tests
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
- * @compile shared/AbstractGenerator.java shared/AccessCheck.java shared/AccessType.java
- *          shared/Caller.java shared/ExecutorGenerator.java shared/Utils.java
- *          shared/ByteArrayClassLoader.java shared/Checker.java shared/GenericClassGenerator.java
  * @compile invokespecial/Checker.java invokespecial/ClassGenerator.java invokespecial/Generator.java
  *
- * @run driver/timeout=1800 invokespecialTests
+ * @run driver/timeout=1800 invokespecialTests current-int
+ */
+
+/*
+ * @test id=current-comp
+ * @bug 8224137
+ * @summary Run invokespecial invocation tests
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokespecial/Checker.java invokespecial/ClassGenerator.java invokespecial/Generator.java
+ *
+ * @run driver/timeout=1800 invokespecialTests current-comp
+ */
+
+/*
+ * @test id=old-int
+ * @bug 8224137
+ * @summary Run invokespecial invocation tests
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokespecial/Checker.java invokespecial/ClassGenerator.java invokespecial/Generator.java
+ *
+ * @run driver/timeout=1800 invokespecialTests old-int
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -69,13 +92,28 @@ public class invokespecialTests {
     }
 
     public static void main(String args[]) throws Throwable {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Should provide the test name");
+        }
+        String testName = args[0];
+
         // Get current major class file version and test with it.
         byte klassbuf[] = InMemoryJavaCompiler.compile("blah", "public class blah { }");
         int major_version = klassbuf[6] << 8 | klassbuf[7];
-        runTest(String.valueOf(major_version), "-Xint");
-        runTest(String.valueOf(major_version), "-Xcomp");
 
-        // Test old class file version.
-        runTest("51", "-Xint"); // JDK-7
+        switch (testName) {
+            case "current-int":
+                runTest(String.valueOf(major_version), "-Xint");
+                break;
+            case "current-comp":
+                runTest(String.valueOf(major_version), "-Xcomp");
+                break;
+            case "old-int":
+                // Test old class file version.
+                runTest("51", "-Xint"); // JDK-7
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown test name: " + testName);
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
@@ -23,18 +23,41 @@
  */
 
 /*
- * @test
+ * @test id=current-int
  * @bug 8224137
  * @summary Run invokevirtual invocation tests
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
- * @compile shared/AbstractGenerator.java shared/AccessCheck.java shared/AccessType.java
- *          shared/Caller.java shared/ExecutorGenerator.java shared/Utils.java
- *          shared/ByteArrayClassLoader.java shared/Checker.java shared/GenericClassGenerator.java
  * @compile invokevirtual/Checker.java invokevirtual/ClassGenerator.java invokevirtual/Generator.java
  *
- * @run driver/timeout=1800 invokevirtualTests
+ * @run driver/timeout=1800 invokevirtualTests current-int
+ */
+
+/*
+ * @test id=current-comp
+ * @bug 8224137
+ * @summary Run invokevirtual invocation tests
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokevirtual/Checker.java invokevirtual/ClassGenerator.java invokevirtual/Generator.java
+ *
+ * @run driver/timeout=1800 invokevirtualTests current-comp
+ */
+
+/*
+ * @test id=old-int
+ * @bug 8224137
+ * @summary Run invokevirtual invocation tests
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ * @compile invokevirtual/Checker.java invokevirtual/ClassGenerator.java invokevirtual/Generator.java
+ *
+ * @run driver/timeout=1800 invokevirtualTests old-int
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -69,13 +92,28 @@ public class invokevirtualTests {
     }
 
     public static void main(String args[]) throws Throwable {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Should provide the test name");
+        }
+        String testName = args[0];
+
         // Get current major class file version and test with it.
         byte klassbuf[] = InMemoryJavaCompiler.compile("blah", "public class blah { }");
         int major_version = klassbuf[6] << 8 | klassbuf[7];
-        runTest(String.valueOf(major_version), "-Xint");
-        runTest(String.valueOf(major_version), "-Xcomp");
 
-        // Test old class file version.
-        runTest("51", "-Xint"); // JDK-7
+        switch (testName) {
+            case "current-int":
+                runTest(String.valueOf(major_version), "-Xint");
+                break;
+            case "current-comp":
+                runTest(String.valueOf(major_version), "-Xcomp");
+                break;
+            case "old-int":
+                // Test old class file version.
+                runTest("51", "-Xint"); // JDK-7
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown test name: " + testName);
+        }
     }
 }


### PR DESCRIPTION
Clean backport to make tests faster and prepare to potential backport of JDK-8272914.

Additional testing:
 - [x] Affected tests still pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272970](https://bugs.openjdk.java.net/browse/JDK-8272970): Parallelize runtime/InvocationTests/


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/66.diff">https://git.openjdk.java.net/jdk17u/pull/66.diff</a>

</details>
