### PR TITLE
8272838: Move CriticalJNI tests out of tier1

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -197,6 +197,7 @@ tier1_gc = \
   :tier1_gc_2 \
   :tier1_gc_gcold \
   :tier1_gc_gcbasher \
+  :tier1_gc_epsilon \
   :tier1_gc_shenandoah
 
 hotspot_not_fast_gc = \
@@ -204,21 +205,27 @@ hotspot_not_fast_gc = \
   -:tier1_gc
 
 tier1_gc_1 = \
-  :gc_epsilon \
   gc/g1/ \
   -gc/g1/ihop/TestIHOPErgo.java
 
 tier1_gc_2 = \
   gc/ \
-  -:gc_epsilon \
+  -gc/CriticalNativeArgs.java \
   -gc/g1/ \
   -gc/logging/TestUnifiedLoggingSwitchStress.java \
   -gc/stress \
   -gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java \
+  -gc/epsilon \
   -gc/shenandoah
 
-gc_epsilon = \
-  gc/epsilon/ \
+hotspot_gc_epsilon = \
+  :tier1_gc_epsilon \
+  :tier2_gc_epsilon
+
+tier1_gc_epsilon = \
+  gc/epsilon/
+
+tier2_gc_epsilon = \
   gc/CriticalNativeArgs.java \
   gc/stress/CriticalNativeStress.java
 
@@ -237,8 +244,7 @@ tier1_gc_shenandoah = \
   gc/shenandoah/compiler/ \
   gc/shenandoah/mxbeans/ \
   gc/shenandoah/TestSmallHeap.java \
-  gc/shenandoah/oom/ \
-  gc/CriticalNativeArgs.java
+  gc/shenandoah/oom/
 
 tier2_gc_shenandoah = \
   runtime/MemberName/MemberNameLeak.java \
@@ -260,9 +266,10 @@ tier2_gc_shenandoah = \
   gc/logging/TestUnifiedLoggingSwitchStress.java \
   runtime/Metaspace/DefineClass.java \
   gc/shenandoah/ \
+  gc/CriticalNativeArgs.java \
+  gc/stress/CriticalNativeStress.java \
   serviceability/sa/TestHeapDumpForInvokeDynamic.java \
   -gc/shenandoah/TestStringDedupStress.java \
-  -gc/stress/CriticalNativeStress.java \
   -:tier1_gc_shenandoah
 
 tier3_gc_shenandoah = \
@@ -271,7 +278,6 @@ tier3_gc_shenandoah = \
   gc/stress/gclocker/TestGCLockerWithShenandoah.java \
   gc/stress/systemgc/TestSystemGCWithShenandoah.java \
   gc/shenandoah/TestStringDedupStress.java \
-  gc/stress/CriticalNativeStress.java \
   -:tier2_gc_shenandoah
 
 hotspot_gc_shenandoah = \


### PR DESCRIPTION
Clean backport to make tests faster and prepare to potential backport of JDK-8272914.

Additional testing:
 - [x] Linux x86_64 `hotspot:tier1` does not include affected tests anymore
 - [x] Linux x86_64 `hotspot_gc_shenandoah` includes affected tests
 - [x] Linux x86_64 `hotspot_gc_epsilon` includes affected tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272838](https://bugs.openjdk.java.net/browse/JDK-8272838): Move CriticalJNI tests out of tier1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/67.diff">https://git.openjdk.java.net/jdk17u/pull/67.diff</a>

</details>
