### PR TITLE
8263375: Support stack watermarks in Zero VM

### DIFF
--- a/src/hotspot/cpu/zero/vm_version_zero.hpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.hpp
@@ -32,6 +32,8 @@
 class VM_Version : public Abstract_VM_Version {
  public:
   static void initialize();
+
+  constexpr static bool supports_stack_watermark_barrier() { return true; }
 };
 
 #endif // CPU_ZERO_VM_VERSION_ZERO_HPP

--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.hpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.hpp
@@ -39,6 +39,9 @@
   static int empty_entry(Method* method, intptr_t UNUSED, TRAPS);
   static int Reference_get_entry(Method* method, intptr_t UNUSED, TRAPS);
 
+  // Stack watermark machinery
+  static void stack_watermark_unwind_check(JavaThread* thread);
+
  public:
   // Main loop of normal_entry
   static void main_loop(int recurse, TRAPS);

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -107,7 +107,7 @@
   There really shouldn't be any handles remaining to trash but this is cheap
   in relation to a safepoint.
 */
-#define SAFEPOINT                                                                                         \
+#define RETURN_SAFEPOINT                                                                                  \
     if (SafepointMechanism::should_process(THREAD)) {                                                     \
       HandleMarkCleaner __hmc(THREAD);                                                                    \
       CALL_VM(SafepointMechanism::process_if_requested_with_exit_check(THREAD, true /* check asyncs */),  \
@@ -1336,34 +1336,20 @@ run:
       CASE(_areturn):
       CASE(_ireturn):
       CASE(_freturn):
-      {
-          // Allow a safepoint before returning to frame manager.
-          SAFEPOINT;
-
-          goto handle_return;
-      }
-
       CASE(_lreturn):
       CASE(_dreturn):
-      {
+      CASE(_return): {
           // Allow a safepoint before returning to frame manager.
-          SAFEPOINT;
+          RETURN_SAFEPOINT;
           goto handle_return;
       }
 
       CASE(_return_register_finalizer): {
-
           oop rcvr = LOCALS_OBJECT(0);
           VERIFY_OOP(rcvr);
           if (rcvr->klass()->has_finalizer()) {
             CALL_VM(InterpreterRuntime::register_finalizer(THREAD, rcvr), handle_exception);
           }
-          goto handle_return;
-      }
-      CASE(_return): {
-
-          // Allow a safepoint before returning to frame manager.
-          SAFEPOINT;
           goto handle_return;
       }
 


### PR DESCRIPTION
Clean backport to improve Zero support.

Additional testing: 
 - [x] Linux x86_64 Zero passes `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263375](https://bugs.openjdk.java.net/browse/JDK-8263375): Support stack watermarks in Zero VM


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/74.diff">https://git.openjdk.java.net/jdk17u/pull/74.diff</a>

</details>
