### PR TITLE
8271722: [TESTBUG] gc/g1/TestMixedGCLiveThreshold.java can fail if G1 Full GC uses >1 workers

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
+++ b/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
@@ -81,6 +81,8 @@ public class TestMixedGCLiveThreshold {
                                        "-XX:+UnlockDiagnosticVMOptions",
                                        "-XX:+UnlockExperimentalVMOptions",
                                        "-XX:+WhiteBoxAPI",
+                                       // Parallel full gc can distribute live objects into different regions.
+                                       "-XX:ParallelGCThreads=1",
                                        "-Xlog:gc+remset+tracking=trace",
                                        "-Xms10M",
                                        "-Xmx10M"});


### PR DESCRIPTION
Hi all,

this pull request contains a clean backport of commit 4abe5311 from the openjdk/jdk repository.
I would like to backport this to 17u to avoid false positives in 17u tests.
The commit being backported was authored by Richard Reingruber on 5 Aug 2021 and was reviewed by Albert Mingkun Yang and Thomas Schatzl.

Thanks!
Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271722](https://bugs.openjdk.java.net/browse/JDK-8271722): [TESTBUG] gc/g1/TestMixedGCLiveThreshold.java can fail if G1 Full GC uses >1 workers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/75.diff">https://git.openjdk.java.net/jdk17u/pull/75.diff</a>

</details>
