### PR TITLE
8272342: [TEST_BUG] java/awt/print/PrinterJob/PageDialogMarginTest.java catches all exceptions

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,10 @@
  *           entry is working
  * @run      main/manual PageDialogMarginTest
  */
-import java.awt.Component;
+
 import java.awt.print.PageFormat;
 import java.awt.print.PrinterJob;
+import java.util.Locale;
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.standard.MediaPrintableArea;
@@ -39,35 +40,31 @@ import javax.swing.SwingUtilities;
 
 public class PageDialogMarginTest {
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
+        Locale.setDefault(Locale.US);
         String[] instructions
                 = {
                     "Page Dialog will be shown.",
                     "Change top(in) margin value from 1.0 to 2.0",
                     "Then select OK."
                 };
-        SwingUtilities.invokeAndWait(() -> {
-            JOptionPane.showMessageDialog((Component) null,
-                    instructions, "Instructions",
-                    JOptionPane.INFORMATION_MESSAGE);
-        });
+        SwingUtilities.invokeAndWait(() -> JOptionPane.showMessageDialog(null,
+                instructions, "Instructions",
+                JOptionPane.INFORMATION_MESSAGE));
         PrinterJob pj = PrinterJob.getPrinterJob();
-        try {
-            HashPrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
-            PageFormat pf;
-            pf = pj.pageDialog(aset);
-            double left = pf.getImageableX();
-            double top = pf.getImageableY();
-            System.out.println("pageDialog - left/top from pageFormat: " + left / 72
-                    + " " + top / 72);
-            System.out.println("pageDialog - left/top from attribute set: "
-                    + getPrintableXFromASet(aset) + " "
-                    + getPrintableYFromASet(aset));
-            if (top / 72 != 2.0f || getPrintableYFromASet(aset) != 2.0f) {
-                throw new RuntimeException("Top margin value not updated");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
+
+        HashPrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
+        PageFormat pf = pj.pageDialog(aset);
+        double left = pf.getImageableX();
+        double top = pf.getImageableY();
+
+        System.out.println("pageDialog - left/top from pageFormat: " + left / 72
+                                   + " " + top / 72);
+        System.out.println("pageDialog - left/top from attribute set: "
+                                   + getPrintableXFromASet(aset) + " "
+                                   + getPrintableYFromASet(aset));
+        if (top / 72 != 2.0f || getPrintableYFromASet(aset) != 2.0f) {
+            throw new RuntimeException("Top margin value not updated");
         }
     }
 


### PR DESCRIPTION
Patch applies cleanly and fixes a test which otherwise always passes. Confirmed on Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272342](https://bugs.openjdk.java.net/browse/JDK-8272342): [TEST_BUG] java/awt/print/PrinterJob/PageDialogMarginTest.java catches all exceptions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/78.diff">https://git.openjdk.java.net/jdk17u/pull/78.diff</a>

</details>
