### PR TITLE
8273646: Add openssl from path variable also in to Default System Openssl Path in OpensslArtifactFetcher

### DIFF
--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -82,8 +82,8 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPath(String version) {
-        if (verifyOpensslVersion("/usr/bin/openssl", version)) {
-            return "/usr/bin/openssl";
+        if (verifyOpensslVersion("openssl", version)) {
+            return "openssl";
         } else if (verifyOpensslVersion("/usr/local/bin/openssl", version)) {
             return "/usr/local/bin/openssl";
         }


### PR DESCRIPTION
This is a straight, clean backport of the following change:

8273646: Add openssl from path variable also in to Default System Openssl Path in OpensslArtifactFetcher

The patch applies cleanly, and the tests pass following the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273646](https://bugs.openjdk.java.net/browse/JDK-8273646): Add openssl from path variable also in to Default System Openssl Path in OpensslArtifactFetcher


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/84.diff">https://git.openjdk.java.net/jdk17u/pull/84.diff</a>

</details>
