### PR TITLE
8272570: C2: crash in PhaseCFG::global_code_motion

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -518,7 +518,7 @@ Node* PhaseCFG::select(
   uint score   = 0; // Bigger is better
   int idx = -1;     // Index in worklist
   int cand_cnt = 0; // Candidate count
-  bool block_size_threshold_ok = (block->number_of_nodes() > 10) ? true : false;
+  bool block_size_threshold_ok = (recalc_pressure_nodes != NULL) && (block->number_of_nodes() > 10);
 
   for( uint i=0; i<cnt; i++ ) { // Inspect entire worklist
     // Order in worklist is used to break ties.
@@ -948,7 +948,7 @@ bool PhaseCFG::schedule_local(Block* block, GrowableArray<int>& ready_cnt, Vecto
     return true;
   }
 
-  bool block_size_threshold_ok = (block->number_of_nodes() > 10) ? true : false;
+  bool block_size_threshold_ok = (recalc_pressure_nodes != NULL) && (block->number_of_nodes() > 10);
 
   // We track the uses of local definitions as input dependences so that
   // we know when a given instruction is avialable to be scheduled.

--- a/test/hotspot/jtreg/compiler/regalloc/TestGCMRecalcPressureNodes.java
+++ b/test/hotspot/jtreg/compiler/regalloc/TestGCMRecalcPressureNodes.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8272570
+ * @summary crash in PhaseCFG::global_code_motion
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -Xbatch TestGCMRecalcPressureNodes
+ */
+
+public class TestGCMRecalcPressureNodes {
+    public boolean bo0;
+    public boolean bo1;
+    public void foo() {
+        int sh12 = 61;
+        for (int i = 0; i < 50; i++) {
+            sh12 *= 34;
+        }
+        Math.tan(1.0);
+        bo0 = true;
+        bo1 = true;
+    }
+    public static void main(String[] args) {
+        TestGCMRecalcPressureNodes instance = new TestGCMRecalcPressureNodes();
+        for (int i = 0; i < 50000; i++) {
+            instance.foo();
+        }
+    }
+}
+


### PR DESCRIPTION
Backport of [JDK-8272570](https://bugs.openjdk.java.net/browse/JDK-8272570). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272570](https://bugs.openjdk.java.net/browse/JDK-8272570): C2: crash in PhaseCFG::global_code_motion


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/94.diff">https://git.openjdk.java.net/jdk17u/pull/94.diff</a>

</details>
