### PR TITLE
8271600: C2: CheckCastPP which should closely follow Allocate is sunk of a loop

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1435,12 +1435,16 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
 // like various versions of induction variable+offset.  Clone the
 // computation per usage to allow it to sink out of the loop.
 void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
+  bool is_raw_to_oop_cast = n->is_ConstraintCast() &&
+                            n->in(1)->bottom_type()->isa_rawptr() &&
+                            !n->bottom_type()->isa_rawptr();
   if (has_ctrl(n) &&
       !n->is_Phi() &&
       !n->is_Bool() &&
       !n->is_Proj() &&
       !n->is_MergeMem() &&
       !n->is_CMove() &&
+      !is_raw_to_oop_cast && // don't extend live ranges of raw oops
       n->Opcode() != Op_Opaque4) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);


### PR DESCRIPTION
Backport of [JDK-8271600](https://bugs.openjdk.java.net/browse/JDK-8271600). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271600](https://bugs.openjdk.java.net/browse/JDK-8271600): C2: CheckCastPP which should closely follow Allocate is sunk of a loop


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/102.diff">https://git.openjdk.java.net/jdk17u/pull/102.diff</a>

</details>
