### PR TITLE
8266239: Some duplicated javac command-line options have repeated effect

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
@@ -1154,6 +1154,11 @@ public enum Option {
             }
             process(helper, option, operand);
         } else {
+            if ((this == HELP || this == X || this == HELP_LINT || this == VERSION || this == FULLVERSION)
+                    && (helper.get(this) != null)) {
+                // avoid processing the info options repeatedly
+                return;
+            }
             process(helper, arg);
         }
     }

--- a/test/langtools/tools/javac/options/modes/InfoOptsTest.java
+++ b/test/langtools/tools/javac/options/modes/InfoOptsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8044859 8230623
+ * @bug 8044859 8230623 8266239
  * @summary test support for info options -help -X -version -fullversion --help-lint
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file
@@ -65,5 +65,23 @@ public class InfoOptsTest extends OptionModesTester {
 
         runParse(opts, files)
                 .checkIllegalArgumentException();
+    }
+
+    @Test
+    void testUniqueInfoOpts() throws IOException {
+        testUniqueInfoOpt(new String[] {"--help", "--help"}, "possible options");
+        testUniqueInfoOpt(new String[] {"-X", "-X"}, "extra options");
+        testUniqueInfoOpt(new String[] {"--help-lint", "--help-lint"}, "supported keys");
+
+        String specVersion = System.getProperty("java.specification.version");
+        testUniqueInfoOpt(new String[] {"-version", "-version"}, "javac", specVersion);
+        testUniqueInfoOpt(new String[] {"-fullversion", "-fullversion"}, "javac", specVersion);
+    }
+
+    void testUniqueInfoOpt(String[] opts, String... expect) {
+        String[] files = { };
+        runMain(opts, files)
+                .checkOK()
+                .checkUniqueLog(expect);
     }
 }

--- a/test/langtools/tools/javac/options/modes/OptionModesTester.java
+++ b/test/langtools/tools/javac/options/modes/OptionModesTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,6 +265,22 @@ public class OptionModesTester {
             for (String e: expects) {
                 if (!logs.get(l).contains(e))
                     error("expected string not found: " + e);
+            }
+            return this;
+        }
+
+        TestResult checkUniqueLog(String... uniqueExpects) {
+            return checkUniqueLog(Log.DIRECT, uniqueExpects);
+        }
+
+        TestResult checkUniqueLog(Log l, String... uniqueExpects) {
+            String log = logs.get(l);
+            for (String e : uniqueExpects) {
+                if (!log.contains(e)) {
+                    error("Expected string not found: " + e);
+                } else if (log.indexOf(e) != log.lastIndexOf(e)) {
+                    error("Expected string appears more than once: " + e);
+                }
             }
             return this;
         }


### PR DESCRIPTION
Hi all,

I would like to backport this change about `javac` command option to jdk17u. The code applies cleanly.

The commit being backported was authored by Guoxiong Li on 14 Sep 2021 and was reviewed by Vicente Romero.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266239](https://bugs.openjdk.java.net/browse/JDK-8266239): Some duplicated javac command-line options have repeated effect


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/110.diff">https://git.openjdk.java.net/jdk17u/pull/110.diff</a>

</details>
