### PR TITLE
8272328: java.library.path is not set properly by Windows jpackage app launcher

### DIFF
--- a/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
@@ -91,6 +91,24 @@ tstring findJvmLib(const CfgFile& cfgFile, const tstring& defaultRuntimePath,
 }
 } // namespace
 
+bool AppLauncher::libEnvVariableContainsAppDir() const {
+    tstring value = SysInfo::getEnvVariable(std::nothrow,
+            libEnvVarName, tstring());
+#ifdef _WIN32
+    value = tstrings::toLower(value);
+#endif
+
+    const tstring_array tokens = tstrings::split(value,
+            tstring(1, FileUtils::pathSeparator));
+    return tokens.end() != std::find(tokens.begin(), tokens.end(),
+#ifdef _WIN32
+        tstrings::toLower(appDirPath)
+#else
+        appDirPath
+#endif
+    );
+}
+
 Jvm* AppLauncher::createJvmLauncher() const {
     const tstring cfgFilePath = FileUtils::mkpath()
         << appDirPath << FileUtils::stripExeSuffix(
@@ -112,8 +130,12 @@ Jvm* AppLauncher::createJvmLauncher() const {
             PropertyName::arguments, args);
     }
 
-    SysInfo::setEnvVariable(libEnvVarName, SysInfo::getEnvVariable(
-            std::nothrow, libEnvVarName) + FileUtils::pathSeparator + appDirPath);
+    if (!libEnvVariableContainsAppDir()) {
+        SysInfo::setEnvVariable(libEnvVarName, SysInfo::getEnvVariable(
+                std::nothrow, libEnvVarName)
+                + FileUtils::pathSeparator
+                + appDirPath);
+    }
 
     std::unique_ptr<Jvm> jvm(new Jvm());
 

--- a/src/jdk.jpackage/share/native/applauncher/AppLauncher.h
+++ b/src/jdk.jpackage/share/native/applauncher/AppLauncher.h
@@ -65,6 +65,8 @@ public:
         return *this;
     }
 
+    bool libEnvVariableContainsAppDir() const;
+
     Jvm* createJvmLauncher() const;
 
     void launch() const;

--- a/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
+++ b/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
@@ -138,17 +138,55 @@ void launchApp() {
 
     const tstring launcherPath = SysInfo::getProcessModulePath();
     const tstring appImageRoot = FileUtils::dirname(launcherPath);
+    const tstring appDirPath = FileUtils::mkpath() << appImageRoot << _T("app");
     const tstring runtimeBinPath = FileUtils::mkpath()
             << appImageRoot << _T("runtime") << _T("bin");
 
-    std::unique_ptr<Jvm> jvm(AppLauncher()
-        .setImageRoot(appImageRoot)
+    const AppLauncher appLauncher = AppLauncher().setImageRoot(appImageRoot)
         .addJvmLibName(_T("bin\\jli.dll"))
-        .setAppDir(FileUtils::mkpath() << appImageRoot << _T("app"))
+        .setAppDir(appDirPath)
         .setLibEnvVariableName(_T("PATH"))
         .setDefaultRuntimePath(FileUtils::mkpath() << appImageRoot
-                << _T("runtime"))
-        .createJvmLauncher());
+            << _T("runtime"));
+
+    const bool restart = !appLauncher.libEnvVariableContainsAppDir();
+
+    std::unique_ptr<Jvm> jvm(appLauncher.createJvmLauncher());
+
+    if (restart) {
+        jvm = std::unique_ptr<Jvm>();
+
+        STARTUPINFOW si;
+        ZeroMemory(&si, sizeof(si));
+        si.cb = sizeof(si);
+
+        PROCESS_INFORMATION pi;
+        ZeroMemory(&pi, sizeof(pi));
+
+        if (!CreateProcessW(launcherPath.c_str(), GetCommandLineW(),
+                NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
+            JP_THROW(SysError(tstrings::any() << "CreateProcessW() failed",
+                                                            CreateProcessW));
+        }
+
+        WaitForSingleObject(pi.hProcess, INFINITE);
+
+        UniqueHandle childProcessHandle(pi.hProcess);
+        UniqueHandle childThreadHandle(pi.hThread);
+
+        DWORD exitCode;
+        if (!GetExitCodeProcess(pi.hProcess, &exitCode)) {
+            JP_THROW(SysError(tstrings::any() << "GetExitCodeProcess() failed",
+                                                        GetExitCodeProcess));
+        }
+
+        if (exitCode != 0) {
+            JP_THROW(tstrings::any() << "Child process exited with code "
+                                                                << exitCode);
+        }
+
+        return;
+    }
 
     // zip.dll may be loaded by java without full path
     // make sure it will look in runtime/bin

--- a/src/jdk.jpackage/windows/native/common/WinSysInfo.cpp
+++ b/src/jdk.jpackage/windows/native/common/WinSysInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,10 +121,6 @@ void setEnvVariable(const tstring& name, const tstring& value)
                 << "SetEnvironmentVariable("
                 << name << ", " << value
                 << ") failed", SetEnvironmentVariable));
-    }
-
-    if (0 != _tputenv_s(name.c_str(), value.c_str())) {
-        JP_THROW(tstrings::any() << "_tputenv_s(" << name << ", " << value << ") failed: " << lastCRTError());
     }
 }
 


### PR DESCRIPTION
clean backport from jdk-18:

Author: Alexey Semenyuk <asemenyuk@openjdk.org>
Date:   Wed Aug 11 20:54:58 2021 +0000

    8272328: java.library.path is not set properly by Windows jpackage app launcher

    Reviewed-by: herrick, almatvee

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272328](https://bugs.openjdk.java.net/browse/JDK-8272328): java.library.path is not set properly by Windows jpackage app launcher


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/111.diff">https://git.openjdk.java.net/jdk17u/pull/111.diff</a>

</details>
