### PR TITLE
8273498: compiler/c2/Test7179138_1.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
@@ -29,7 +29,7 @@
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
  *      compiler.c2.Test7179138_1
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
- *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:RepeatCompilation=100 compiler.c2.Test7179138_1
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN compiler.c2.Test7179138_1
  *
  * @author Skip Balk
  */


### PR DESCRIPTION
Backport of [JDK-8273498](https://bugs.openjdk.java.net/browse/JDK-8273498). Did not apply cleanly because I had to omit the changes to the ProblemList (the test is not problem listed in JDK 17u). Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273498](https://bugs.openjdk.java.net/browse/JDK-8273498): compiler/c2/Test7179138_1.java timed out


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/114.diff">https://git.openjdk.java.net/jdk17u/pull/114.diff</a>

</details>
