### PR TITLE
8274087: Windows DLL path not set correctly.

### DIFF
--- a/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
+++ b/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
@@ -139,8 +139,6 @@ void launchApp() {
     const tstring launcherPath = SysInfo::getProcessModulePath();
     const tstring appImageRoot = FileUtils::dirname(launcherPath);
     const tstring appDirPath = FileUtils::mkpath() << appImageRoot << _T("app");
-    const tstring runtimeBinPath = FileUtils::mkpath()
-            << appImageRoot << _T("runtime") << _T("bin");
 
     const AppLauncher appLauncher = AppLauncher().setImageRoot(appImageRoot)
         .addJvmLibName(_T("bin\\jli.dll"))
@@ -188,9 +186,11 @@ void launchApp() {
         return;
     }
 
-    // zip.dll may be loaded by java without full path
+    // zip.dll (and others) may be loaded by java without full path
     // make sure it will look in runtime/bin
+    const tstring runtimeBinPath = FileUtils::dirname(jvm->getPath());
     SetDllDirectory(runtimeBinPath.c_str());
+    LOG_TRACE(tstrings::any() << "SetDllDirectory to: " << runtimeBinPath);
 
     const DllWrapper jliDll(jvm->getPath());
     std::unique_ptr<DllWrapper> splashDll;


### PR DESCRIPTION
clean backport of: JDK-8274087: Windows DLL path not set correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274087](https://bugs.openjdk.java.net/browse/JDK-8274087): Windows DLL path not set correctly.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/116.diff">https://git.openjdk.java.net/jdk17u/pull/116.diff</a>

</details>
