### PR TITLE
8273887: [macos] java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java timed out

### DIFF
--- a/test/jdk/java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java
@@ -110,7 +110,7 @@ public final class MTTransformReplacedProfile {
         float[] colorvalue = new float[3];
         Thread transform = new Thread(() -> {
             boolean rgb = true;
-            while (!stop.get()) {
+            while (!stop.get() && !isComplete()) {
                 try {
                     if (rgb) {
                         cs.toRGB(colorvalue);


### PR DESCRIPTION
Hi all,

This is update of the the test to make its execution time less, see https://github.com/openjdk/jdk/pull/5587 for additional details.

this pull request contains a backport of commit 1bd11a7f from the openjdk/jdk repository.

The commit being backported was authored by Sergey Bylokhov on 20 Sep 2021 and was reviewed by Alexey Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273887](https://bugs.openjdk.java.net/browse/JDK-8273887): [macos] java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java timed out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/118.diff">https://git.openjdk.java.net/jdk17u/pull/118.diff</a>

</details>
