### PR TITLE
8271287: jdk/jshell/CommandCompletionTest.java fails with "lists don't have the same size expected"

### DIFF
--- a/test/langtools/jdk/jshell/CommandCompletionTest.java
+++ b/test/langtools/jdk/jshell/CommandCompletionTest.java
@@ -332,14 +332,22 @@ public class CommandCompletionTest extends ReplToolTesting {
     public void testUserHome() throws IOException {
         List<String> completions;
         Path home = Paths.get(System.getProperty("user.home"));
+        String selectedFile;
+        try (Stream<Path> content = Files.list(home)) {
+            selectedFile = content.filter(CLASSPATH_FILTER)
+                                  .findAny()
+                                  .map(file -> file.getFileName().toString())
+                                  .get();
+        }
         try (Stream<Path> content = Files.list(home)) {
             completions = content.filter(CLASSPATH_FILTER)
+                                 .filter(file -> file.getFileName().toString().startsWith(selectedFile))
                                  .map(file -> file.getFileName().toString() + (Files.isDirectory(file) ? "/" : ""))
                                  .sorted()
                                  .collect(Collectors.toList());
         }
         testNoStartUp(
-                a -> assertCompletion(a, "/env --class-path ~/|", false, completions.toArray(new String[completions.size()]))
+                a -> assertCompletion(a, "/env --class-path ~/" + selectedFile + "|", false, completions.toArray(new String[completions.size()]))
         );
     }
 


### PR DESCRIPTION
This is a straight, clean backport of the following bug:

8271287: jdk/jshell/CommandCompletionTest.java fails with "lists don't have the same size expected"

The patch applies clean, and the test passes on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271287](https://bugs.openjdk.java.net/browse/JDK-8271287): jdk/jshell/CommandCompletionTest.java fails with "lists don't have the same size expected"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/121.diff">https://git.openjdk.java.net/jdk17u/pull/121.diff</a>

</details>
