### PR TITLE
8273378: Shenandoah: Remove the remaining uses of os::is_MP

### DIFF
--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -682,13 +682,14 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   //
   // Try to CAS with given arguments. If successful, then we are done.
 
-  if (os::is_MP()) __ lock();
 #ifdef _LP64
   if (UseCompressedOops) {
+    __ lock();
     __ cmpxchgl(newval, addr);
   } else
 #endif
   {
+    __ lock();
     __ cmpxchgptr(newval, addr);
   }
   __ jcc(Assembler::equal, L_success);
@@ -765,13 +766,14 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   }
 #endif
 
-  if (os::is_MP()) __ lock();
 #ifdef _LP64
   if (UseCompressedOops) {
+    __ lock();
     __ cmpxchgl(tmp2, addr);
   } else
 #endif
   {
+    __ lock();
     __ cmpxchgptr(tmp2, addr);
   }
 
@@ -791,13 +793,14 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
     __ movptr(oldval, tmp2);
   }
 
-  if (os::is_MP()) __ lock();
 #ifdef _LP64
   if (UseCompressedOops) {
+    __ lock();
     __ cmpxchgl(newval, addr);
   } else
 #endif
   {
+    __ lock();
     __ cmpxchgptr(newval, addr);
   }
   if (!exchange) {


### PR DESCRIPTION
Clean backport to keep codebases in sync and avoid surprises when `os::is_MP` is misbehaving.

Additional testing:
 - [x] `hotspot_gc_shenandoah` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273378](https://bugs.openjdk.java.net/browse/JDK-8273378): Shenandoah: Remove the remaining uses of os::is_MP


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/123.diff">https://git.openjdk.java.net/jdk17u/pull/123.diff</a>

</details>
