### PR TITLE
8272914: Create hotspot:tier2 and hotspot:tier3 test groups

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -450,6 +450,17 @@ tier1 = \
   :tier1_runtime \
   :tier1_serviceability
 
+tier2 = \
+  :hotspot_tier2_runtime \
+  :hotspot_tier2_runtime_platform_agnostic \
+  :hotspot_tier2_serviceability \
+  :tier2_gc_epsilon \
+  :tier2_gc_shenandoah
+
+tier3 = \
+  :hotspot_tier3_runtime \
+  :tier3_gc_shenandoah
+
 hotspot_tier2_runtime = \
   runtime/ \
  -runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java \


### PR DESCRIPTION
Clean backport to improve testing capabilities.

Additional testing:
 - [x] Linux x86_64 `hotspot:tier2` passes
 - [x] Linux x86_64 `hotspot:tier3` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272914](https://bugs.openjdk.java.net/browse/JDK-8272914): Create hotspot:tier2 and hotspot:tier3 test groups


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/124.diff">https://git.openjdk.java.net/jdk17u/pull/124.diff</a>

</details>
