### PR TITLE
8273318: Some containers/docker/TestJFREvents.java configs are running out of memory

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -82,13 +82,14 @@ public class TestJFREvents {
     }
 
     private static void containerInfoTestCase() throws Exception {
-            // leave one CPU for system and tools, otherwise this test may be unstable
-            int maxNrOfAvailableCpus =  availableCPUs - 1;
-            for (int i=1; i < maxNrOfAvailableCpus; i = i * 2) {
-                for (int j=64; j <= 256; j *= 2) {
-                    testContainerInfo(i, j);
-                }
+        // Leave one CPU for system and tools, otherwise this test may be unstable.
+        // Try the memory sizes that were verified by testMemory tests before.
+        int maxNrOfAvailableCpus = availableCPUs - 1;
+        for (int cpus = 1; cpus < maxNrOfAvailableCpus; cpus *= 2) {
+            for (int mem : new int[]{ 200, 500, 1024 }) {
+                testContainerInfo(cpus, mem);
             }
+        }
     }
 
     private static void testContainerInfo(int expectedCPUs, int expectedMemoryMB) throws Exception {


### PR DESCRIPTION
Clean backport to fix the test.

Additional testing: 
 - [x] Affected test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273318](https://bugs.openjdk.java.net/browse/JDK-8273318): Some containers/docker/TestJFREvents.java configs are running out of memory


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/125.diff">https://git.openjdk.java.net/jdk17u/pull/125.diff</a>

</details>
