### PR TITLE
8273315: Parallelize and increase timeouts for java/foreign/TestMatrix.java test

### DIFF
--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -1,255 +1,446 @@
 /*
- * @test
+ * Note: to run this test manually, you need to build the tests first to get native
+ * libraries compiled, and then execute it with plain jtreg, like:
+ *
+ *  $ bin/jtreg -jdk:<path-to-tested-jdk> \
+ *              -nativepath:<path-to-build-dir>/support/test/jdk/jtreg/native/lib/ \
+ *              -concurrency:auto \
+ *              ./test/jdk/java/foreign/TestMatrix.java
+ */
+
+/*
+ * @test id=UpcallHighArity-FFTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TFTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
-  * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcallHighArity
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FTTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcallHighArity
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TTTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcallHighArity
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FFTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TFTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FTTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TTTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FFFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TFFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FTFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TTFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FFFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TFFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FTFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TTFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native/manual
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ */
+
+/* @test id=Downcall-FF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestDowncall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   TestDowncall
- * @run testng/othervm
+ */
+
+/* @test id=Downcall-TF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestDowncall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   TestDowncall
- * @run testng/othervm
+ */
+
+/* @test id=Downcall-FT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestDowncall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   TestDowncall
- * @run testng/othervm
+ */
+
+/* @test id=Downcall-TT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestDowncall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   TestDowncall
+ */
+
+/* @test id=Upcall-TFTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
- * @run testng/othervm
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcall
- * @run testng/othervm
+ */
+
+/* @test id=Upcall-FTTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
- * @run testng/othervm
+ */
+
+/* @test id=Upcall-TTTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
+ */
+
+/* @test id=Upcall-TFTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
- * @run testng/othervm
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcall
- * @run testng/othervm
+ */
+
+/* @test id=Upcall-FTTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
- * @run testng/othervm
+ */
+
+/* @test id=Upcall-TTTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
+ */
+
+/* @test id=Upcall-TFFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
- * @run testng/othervm
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcall
- * @run testng/othervm
+ */
+
+/* @test id=Upcall-FTFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
- * @run testng/othervm
+ */
+
+/* @test id=Upcall-TTFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
+ */
+
+/* @test id=Upcall-TFFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
- * @run testng/othervm
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcall
- * @run testng/othervm
+ */
+
+/* @test id=Upcall-FTFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
- * @run testng/othervm
+ */
+
+/* @test id=Upcall-TTFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
+ *
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] The test does not run with `make test` anymore (as expected)
 - [x] The test passes with manual jtreg invocation (as expected)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273315](https://bugs.openjdk.java.net/browse/JDK-8273315): Parallelize and increase timeouts for java/foreign/TestMatrix.java test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/126/head:pull/126` \
`$ git checkout pull/126`

Update a local copy of the PR: \
`$ git checkout pull/126` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 126`

View PR using the GUI difftool: \
`$ git pr show -t 126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/126.diff">https://git.openjdk.java.net/jdk17u/pull/126.diff</a>

</details>
