### PR TITLE
8272836: Limit run time for java/lang/invoke/LFCaching tests

### DIFF
--- a/test/jdk/java/lang/invoke/LFCaching/LambdaFormTestCase.java
+++ b/test/jdk/java/lang/invoke/LFCaching/LambdaFormTestCase.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 public abstract class LambdaFormTestCase {
 
     private static final long TIMEOUT = Helper.IS_THOROUGH ?
-            0L : (long) (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.9);
+            0L : (long) (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.2);
 
     /**
      * Reflection link to {@code j.l.i.MethodHandle.internalForm} method. It is


### PR DESCRIPTION
Clean backport to improve testing performance.

Additional testing:
 - [x] Affected test passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272836](https://bugs.openjdk.java.net/browse/JDK-8272836): Limit run time for java/lang/invoke/LFCaching tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/127.diff">https://git.openjdk.java.net/jdk17u/pull/127.diff</a>

</details>
