### PR TITLE
8268361: Fix the infinite loop in next_line

### DIFF
--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -63,8 +63,13 @@ static struct perfbuf {
 #define DEC_64 "%"SCNd64
 #define NS_PER_SEC 1000000000
 
-static void next_line(FILE *f) {
-    while (fgetc(f) != '\n');
+static int next_line(FILE *f) {
+    int c;
+    do {
+        c = fgetc(f);
+    } while (c != '\n' && c != EOF);
+
+    return c;
 }
 
 /**
@@ -93,7 +98,10 @@ static int get_totalticks(int which, ticks *pticks) {
            &iowTicks, &irqTicks, &sirqTicks);
 
     // Move to next line
-    next_line(fh);
+    if (next_line(fh) == EOF) {
+        fclose(fh);
+        return -2;
+    }
 
     //find the line for requested cpu faster to just iterate linefeeds?
     if (which != -1) {
@@ -106,7 +114,10 @@ static int get_totalticks(int which, ticks *pticks) {
                 fclose(fh);
                 return -2;
             }
-            next_line(fh);
+            if (next_line(fh) == EOF) {
+                fclose(fh);
+                return -2;
+            }
         }
         n = fscanf(fh, "cpu%*d " DEC_64 " " DEC_64 " " DEC_64 " " DEC_64 " "
                        DEC_64 " " DEC_64 " " DEC_64 "\n",


### PR DESCRIPTION
Clean backport of a minor fix. Testing: ran jtreg:jdk_management on Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268361](https://bugs.openjdk.java.net/browse/JDK-8268361): Fix the infinite loop in next_line


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/130.diff">https://git.openjdk.java.net/jdk17u/pull/130.diff</a>

</details>
