### PR TITLE
8273806: compiler/cpuflags/TestSSE4Disabled.java should test for CPU feature explicitly

### DIFF
--- a/test/hotspot/jtreg/compiler/cpuflags/TestSSE4Disabled.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestSSE4Disabled.java
@@ -24,7 +24,7 @@
 /*
  * @test TestSSE4Disabled
  * @bug 8158214
- * @requires (vm.simpleArch == "x64")
+ * @requires vm.cpu.features ~= ".*sse4.*"
  * @summary Test correct execution without SSE 4.
  *
  * @run main/othervm -Xcomp -XX:UseSSE=3 compiler.cpuflags.TestSSE4Disabled


### PR DESCRIPTION
Clean backport for Zero testing.

Additional testing:
 - [x] Affected test still passes for Server, disabled for Zero

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273806](https://bugs.openjdk.java.net/browse/JDK-8273806): compiler/cpuflags/TestSSE4Disabled.java should test for CPU feature explicitly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/131.diff">https://git.openjdk.java.net/jdk17u/pull/131.diff</a>

</details>
