### PR TITLE
Backport 1c5de8b86b038f5d5c313c504a8868e36fc80bde

### DIFF
--- a/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
+++ b/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
@@ -47,11 +47,6 @@ public class NumCompilerThreadsCheck {
 
     String expectedOutput = "outside the allowed range";
     out.shouldContain(expectedOutput);
-
-    if (Platform.isZero()) {
-      String expectedLowWaterMarkText = "must be at least 0";
-      out.shouldContain(expectedLowWaterMarkText);
-    }
   }
 
 }


### PR DESCRIPTION
Another Zero testing fix.

Additional testing:
 - [x] Affected test runs Zero properly now