### PR TITLE
8273335: compiler/blackhole tests should not run with interpreter-only VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeExistingIntrinsicWarningTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeExistingIntrinsicWarningTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeExistingIntrinsicWarningTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeExperimentalUnlockTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeIntrinsicTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeIntrinsicTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeIntrinsicTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNonEmptyWarningTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNonEmptyWarningTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeNonEmptyWarningTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNonStaticWarningTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNonStaticWarningTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeNonStaticWarningTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNonVoidWarningTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNonVoidWarningTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeNonVoidWarningTest
  */
 


### PR DESCRIPTION
Clean backport to improve test compatibility.

Additional testing:
 - [x] `compiler/blackhole` tests still run with Server
 - [x] `compiler/blackhole` tests are now skipped with Zero

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273335](https://bugs.openjdk.java.net/browse/JDK-8273335): compiler/blackhole tests should not run with interpreter-only VMs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/133.diff">https://git.openjdk.java.net/jdk17u/pull/133.diff</a>

</details>
