### PR TITLE
8273333: Zero should warn about unimplemented -XX:+LogTouchedMethods

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4048,6 +4048,11 @@ jint Arguments::apply_ergo() {
   // Clear flags not supported on zero.
   FLAG_SET_DEFAULT(ProfileInterpreter, false);
   FLAG_SET_DEFAULT(UseBiasedLocking, false);
+
+  if (LogTouchedMethods) {
+    warning("LogTouchedMethods is not supported for Zero");
+    FLAG_SET_DEFAULT(LogTouchedMethods, false);
+  }
 #endif // ZERO
 
   if (PrintAssembly && FLAG_IS_DEFAULT(DebugNonSafepoints)) {

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 8025692
+ * @bug 8025692 8273333
+ * @requires vm.flavor != "zero"
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @library /test/lib


### PR DESCRIPTION
Semi-clean backport to fix another `tier1` test for Zero. There is a minor contextual conflict -- `UseBiasedLocking` disabling statement is still there in `arguments.cpp` in 17.

Additional testing:
 - [x] Affected tests now skipped for Zero

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273333](https://bugs.openjdk.java.net/browse/JDK-8273333): Zero should warn about unimplemented -XX:+LogTouchedMethods


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/134.diff">https://git.openjdk.java.net/jdk17u/pull/134.diff</a>

</details>
