### PR TITLE
8273483: Zero: Clear pending JNI exception check in native method handler

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -562,6 +562,12 @@ int ZeroInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
     }
   }
 
+  // Already did every pending exception check here.
+  // If HAS_PENDING_EXCEPTION is true, the interpreter would handle the rest.
+  if (CheckJNICalls) {
+    THREAD->clear_pending_jni_exception_check();
+  }
+
   // No deoptimized frames on the stack
   return 0;
 }


### PR DESCRIPTION
Fixes another Zero bug that manifests as `tier1` test failure.

Additional testing: 
 - [x] Affected tests now pass with Zero

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273483](https://bugs.openjdk.java.net/browse/JDK-8273483): Zero: Clear pending JNI exception check in native method handler


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/136.diff">https://git.openjdk.java.net/jdk17u/pull/136.diff</a>

</details>
