### PR TITLE
8273440: Zero: Disable runtime/Unsafe/InternalErrorTest.java

### DIFF
--- a/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
+++ b/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8191278
  * @requires os.family != "windows"
+ * @requires vm.flavor != "zero"
  * @summary Check that SIGBUS errors caused by memory accesses in Unsafe_CopyMemory()
  * and UnsafeCopySwapMemory() get converted to java.lang.InternalError exceptions.
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Fixes another Zero test bug for `tier1`.

Additional testing:
 - [x] Linux x86_64 Zero now skips the test
 - [x] Linux x86_64 Server still runs the test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273440](https://bugs.openjdk.java.net/browse/JDK-8273440): Zero: Disable runtime/Unsafe/InternalErrorTest.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/137.diff">https://git.openjdk.java.net/jdk17u/pull/137.diff</a>

</details>
