### PR TITLE
8274435: EXCEPTION_ACCESS_VIOLATION in BFSClosure::closure_impl

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ BitSet::BitSet() :
     _bitmap_fragments(32),
     _fragment_list(NULL),
     _last_fragment_bits(NULL),
-    _last_fragment_granule(0) {
+    _last_fragment_granule(UINTPTR_MAX) {
 }
 
 BitSet::~BitSet() {


### PR DESCRIPTION
I'd like to backport this fix to jdk17u. It prevents JVM crashes during JFR path to GC roots calculation.
The patch applies cleanly, tested with jdk/jfr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274435](https://bugs.openjdk.java.net/browse/JDK-8274435): EXCEPTION_ACCESS_VIOLATION in BFSClosure::closure_impl


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/139.diff">https://git.openjdk.java.net/jdk17u/pull/139.diff</a>

</details>
