### PR TITLE
8269269: [macos11] SystemIconTest fails with ClassCastException

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/SystemIconTest.java
@@ -73,30 +73,39 @@ public class SystemIconTest {
     static void testSystemIcon(File file, boolean implComplete) {
         int[] sizes = new int[] {16, 32, 48, 64, 128};
         for (int size : sizes) {
-            ImageIcon icon = (ImageIcon) fsv.getSystemIcon(file, size, size);
+            Icon i = fsv.getSystemIcon(file, size, size);
 
+            if (i == null) {
+                throw new RuntimeException(file.getAbsolutePath() + " icon is null");
+            }
+
+            if (!(i instanceof ImageIcon)) {
+                // Default UI resource icon returned - it is not covered
+                // by new implementation so we can not test it
+                continue;
+            }
+
+            ImageIcon icon = (ImageIcon) i;
             //Enable below to see the icon
             //JLabel label = new JLabel(icon);
             //JOptionPane.showMessageDialog(null, label);
 
-            if (icon == null) {
-                throw new RuntimeException("icon is null!!!");
-            }
-
             if (implComplete && icon.getIconWidth() != size) {
                 throw new RuntimeException("Wrong icon size " +
-                        icon.getIconWidth() + " when requested " + size);
+                        icon.getIconWidth() + " when requested " + size +
+                         " for file " + file.getAbsolutePath());
             }
 
             if (icon.getImage() instanceof MultiResolutionImage) {
                 MultiResolutionImage mri = (MultiResolutionImage) icon.getImage();
                 if (mri.getResolutionVariant(size, size) == null) {
                     throw new RuntimeException("There is no suitable variant for the size "
-                            + size + " in the multi resolution icon");
+                            + size + " in the multi resolution icon " + file.getAbsolutePath());
                 }
             } else {
                 if (implComplete) {
-                    throw new RuntimeException("icon is supposed to be multi-resolution but it is not");
+                    throw new RuntimeException("icon is supposed to be" +
+                            " multi-resolution but it is not for " + file.getAbsolutePath());
                 }
             }
         }


### PR DESCRIPTION
Clean backport of the test-only Mac-specific fix.

Testing: checked that the test fails on Mac without the patch, checked that changed test passes on Linux, Windows and Mac.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269269](https://bugs.openjdk.java.net/browse/JDK-8269269): [macos11] SystemIconTest fails with ClassCastException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/142.diff">https://git.openjdk.java.net/jdk17u/pull/142.diff</a>

</details>
