### PR TITLE
8273361: InfoOptsTest is failing in tier1

### DIFF
--- a/test/langtools/tools/javac/options/modes/InfoOptsTest.java
+++ b/test/langtools/tools/javac/options/modes/InfoOptsTest.java
@@ -69,19 +69,23 @@ public class InfoOptsTest extends OptionModesTester {
 
     @Test
     void testUniqueInfoOpts() throws IOException {
-        testUniqueInfoOpt(new String[] {"--help", "--help"}, "possible options");
-        testUniqueInfoOpt(new String[] {"-X", "-X"}, "extra options");
-        testUniqueInfoOpt(new String[] {"--help-lint", "--help-lint"}, "supported keys");
+        testUniqueInfoOpt(new String[] {"--help"},       new String[] {"--help", "--help"});
+        testUniqueInfoOpt(new String[] {"-X"},           new String[] {"-X", "-X"});
+        testUniqueInfoOpt(new String[] {"--help-lint"},  new String[] {"--help-lint", "--help-lint"});
 
-        String specVersion = System.getProperty("java.specification.version");
-        testUniqueInfoOpt(new String[] {"-version", "-version"}, "javac", specVersion);
-        testUniqueInfoOpt(new String[] {"-fullversion", "-fullversion"}, "javac", specVersion);
+        testUniqueInfoOpt(new String[] {"-version"},     new String[] {"-version", "-version"});
+        testUniqueInfoOpt(new String[] {"-fullversion"}, new String[] {"-fullversion", "-fullversion"});
     }
 
-    void testUniqueInfoOpt(String[] opts, String... expect) {
+    void testUniqueInfoOpt(String[] baseOpts, String[] testOpts) {
         String[] files = { };
-        runMain(opts, files)
-                .checkOK()
-                .checkUniqueLog(expect);
+
+        TestResult base = runMain(baseOpts, files)
+                                 .checkOK();
+
+        TestResult test = runMain(testOpts, files)
+                                 .checkOK();
+
+        base.checkSameLog(test);
     }
 }

--- a/test/langtools/tools/javac/options/modes/OptionModesTester.java
+++ b/test/langtools/tools/javac/options/modes/OptionModesTester.java
@@ -269,18 +269,15 @@ public class OptionModesTester {
             return this;
         }
 
-        TestResult checkUniqueLog(String... uniqueExpects) {
-            return checkUniqueLog(Log.DIRECT, uniqueExpects);
+        TestResult checkSameLog(TestResult other) {
+            return checkSameLog(Log.DIRECT, other);
         }
 
-        TestResult checkUniqueLog(Log l, String... uniqueExpects) {
-            String log = logs.get(l);
-            for (String e : uniqueExpects) {
-                if (!log.contains(e)) {
-                    error("Expected string not found: " + e);
-                } else if (log.indexOf(e) != log.lastIndexOf(e)) {
-                    error("Expected string appears more than once: " + e);
-                }
+        TestResult checkSameLog(Log l, TestResult other) {
+            String thisLog = logs.get(l);
+            String otherLog = other.logs.get(l);
+            if (!thisLog.equals(otherLog)) {
+                error("Logs are not the same.\nThis:\n" + thisLog + "\nOther:\n" + otherLog);
             }
             return this;
         }


### PR DESCRIPTION
Clean backport to unbreak 17u GHA. InfoOpts test fails there, currently.

Additional testing: 
 - [x] `InfoOptsTest` passes locally
 - [x] `InfoOptsTest` passes in GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273361](https://bugs.openjdk.java.net/browse/JDK-8273361): InfoOptsTest is failing in tier1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/143.diff">https://git.openjdk.java.net/jdk17u/pull/143.diff</a>

</details>
