### PR TITLE
8273376: Zero: Disable vtable/itableStub gtests

### DIFF
--- a/test/hotspot/gtest/code/test_vtableStub.cpp
+++ b/test/hotspot/gtest/code/test_vtableStub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "unittest.hpp"
 
+#ifndef ZERO
+
 TEST_VM(code, vtableStubs) {
   // Should be in VM to use locks
   ThreadInVMfromNative ThreadInVMfromNative(JavaThread::current());
@@ -50,3 +52,5 @@ TEST_VM(code, itableStubs) {
   }
   VtableStubs::find_itable_stub((1 << 15) - 1); // max itable index
 }
+
+#endif


### PR DESCRIPTION
Clean backport to fix Zero gtests.

Additional testing:
 - [x] Linux x86_64, all gtests now pass with Zero

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273376](https://bugs.openjdk.java.net/browse/JDK-8273376): Zero: Disable vtable/itableStub gtests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/146.diff">https://git.openjdk.java.net/jdk17u/pull/146.diff</a>

</details>
