### PR TITLE
8273487: Zero: Handle "zero" variant in runtime tests

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -364,6 +364,11 @@ public class Platform {
             return "client";
         } else if (Platform.isMinimal()) {
             return "minimal";
+        } else if (Platform.isZero()) {
+            // This name is used to search for libjvm.so. Weirdly, current
+            // build system puts libjvm.so into default location, which is
+            // "server". See JDK-8273494.
+            return "server";
         } else {
             throw new Error("TESTBUG: unsupported vm variant");
         }


### PR DESCRIPTION
Clean backport to fix a few other `tier1` tests for Zero.

Addtional testing:
 - [x] Linux x86_64 Zero affected tests (StackGap, StackGuardPages, TestTLS) now pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273487](https://bugs.openjdk.java.net/browse/JDK-8273487): Zero: Handle "zero" variant in runtime tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/147.diff">https://git.openjdk.java.net/jdk17u/pull/147.diff</a>

</details>
