### PR TITLE
8274349: ForkJoinPool.commonPool() does not work with 1 CPU

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -2561,7 +2561,7 @@ public class ForkJoinPool extends AbstractExecutorService {
      * overridden by system properties
      */
     private ForkJoinPool(byte forCommonPoolOnly) {
-        int parallelism = Runtime.getRuntime().availableProcessors() - 1;
+        int parallelism = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
         ForkJoinWorkerThreadFactory fac = null;
         UncaughtExceptionHandler handler = null;
         try {  // ignore exceptions in accessing/parsing properties

--- a/test/jdk/java/util/concurrent/forkjoin/Uniprocessor.java
+++ b/test/jdk/java/util/concurrent/forkjoin/Uniprocessor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8274349
+ * @run main/othervm -XX:ActiveProcessorCount=1 Uniprocessor
+ * @summary Check the default FJ pool has a reasonable default parallelism
+ *          level in a uniprocessor environment.
+ */
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
+
+public class Uniprocessor {
+
+    static volatile boolean done = false;
+
+    public static void main(String[] args) throws InterruptedException {
+        // If the default parallelism were zero then this task would not
+        // complete and the test will timeout.
+        CountDownLatch ran = new CountDownLatch(1);
+        ForkJoinPool.commonPool().submit(() -> ran.countDown());
+        ran.await();
+    }
+}


### PR DESCRIPTION
Hi all,

    this pull request contains a backport of commit 2e542e33 from the openjdk/jdk repository.

    The commit being backported was authored by David Holmes on 4 Oct 2021 and was reviewed by Aleksey Shipilev and Martin Buchholz.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274349](https://bugs.openjdk.java.net/browse/JDK-8274349): ForkJoinPool.commonPool() does not work with 1 CPU


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/151.diff">https://git.openjdk.java.net/jdk17u/pull/151.diff</a>

</details>
