### PR TITLE
8262095: NPE in Flow$FlowAnalyzer.visitApply: Cannot invoke getThrownTypes because tree.meth.type is null

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -613,7 +613,10 @@ public class Attr extends JCTree.Visitor {
                 }
                 @Override
                 public void report(DiagnosticPosition pos, JCDiagnostic details) {
-                    if (pt == Type.recoveryType) {
+                    boolean needsReport = pt == Type.recoveryType ||
+                            (details.getDiagnosticPosition() != null &&
+                            details.getDiagnosticPosition().getTree().hasTag(LAMBDA));
+                    if (needsReport) {
                         chk.basicHandler.report(pos, details);
                     }
                 }

--- a/test/langtools/tools/javac/lambda/8262095/T8262095.java
+++ b/test/langtools/tools/javac/lambda/8262095/T8262095.java
@@ -1,0 +1,20 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8262095
+ * @summary Report diagnostics produced by incorrect lambdas
+ * @compile/fail/ref=T8262095.out -XDrawDiagnostics T8262095.java
+ */
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+class T8262095 {
+
+    void f(Stream<Entry<Long, List<String>>> stream) {
+        stream.sorted(Entry.comparingByKey()
+                           .thenComparing((Map.Entry<Long, List<String>> e) -> e.getValue().hashCode()))
+              .count();
+    }
+}

--- a/test/langtools/tools/javac/lambda/8262095/T8262095.out
+++ b/test/langtools/tools/javac/lambda/8262095/T8262095.out
@@ -1,0 +1,2 @@
+T8262095.java:17:42: compiler.err.prob.found.req: (compiler.misc.infer.no.conforming.assignment.exists: U, (compiler.misc.inconvertible.types: java.util.function.Function<java.util.Map.Entry<java.lang.Long,java.util.List<java.lang.String>>,java.lang.Integer>, java.util.function.Function<? super java.util.Map.Entry<K,java.lang.Object>,? extends java.lang.Integer>))
+1 error


### PR DESCRIPTION
I'd like to backport JDK-8262095 to 17u. It prevents NPE in javac.
The patch applies cleanly.
Tested with langtools tests, new test fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262095](https://bugs.openjdk.java.net/browse/JDK-8262095): NPE in Flow$FlowAnalyzer.visitApply: Cannot invoke getThrownTypes because tree.meth.type is null


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/152/head:pull/152` \
`$ git checkout pull/152`

Update a local copy of the PR: \
`$ git checkout pull/152` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 152`

View PR using the GUI difftool: \
`$ git pr show -t 152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/152.diff">https://git.openjdk.java.net/jdk17u/pull/152.diff</a>

</details>
