### PR TITLE
8267256: Extend minimal retry for loopback connections on Windows to PlainSocketImpl

### DIFF
--- a/src/java.base/windows/native/libnet/PlainSocketImpl.c
+++ b/src/java.base/windows/native/libnet/PlainSocketImpl.c
@@ -137,7 +137,7 @@ JNIEXPORT jint JNICALL Java_java_net_PlainSocketImpl_connect0
     if (so_rv == 0 && type == SOCK_STREAM && IS_LOOPBACK_ADDRESS(&sa)) {
         NET_EnableFastTcpLoopbackConnect(fd);
     }
-    
+
     rv = connect(fd, &sa.sa, sa_len);
     if (rv == SOCKET_ERROR) {
         int err = WSAGetLastError();

--- a/src/java.base/windows/native/libnet/PlainSocketImpl.c
+++ b/src/java.base/windows/native/libnet/PlainSocketImpl.c
@@ -118,6 +118,9 @@ JNIEXPORT jint JNICALL Java_java_net_PlainSocketImpl_connect0
   (JNIEnv *env, jclass clazz, jint fd, jobject iaObj, jint port) {
     SOCKETADDRESS sa;
     int rv, sa_len = 0;
+    int so_rv;
+    SOCKET s = (SOCKET)fd;
+    int type = 0, optlen = sizeof(type);
     jboolean v4MappedAddress = ipv6_available() ? JNI_TRUE : JNI_FALSE;
 
     if (NET_InetAddressToSockaddr(env, iaObj, port, &sa,
@@ -125,6 +128,16 @@ JNIEXPORT jint JNICALL Java_java_net_PlainSocketImpl_connect0
         return -1;
     }
 
+    so_rv = getsockopt(s, SOL_SOCKET, SO_TYPE, (char*)&type, &optlen);
+
+    /**
+     * Windows has a very long socket connect timeout of 2 seconds.
+     * If it's the loopback adapter we can shorten the wait interval.
+     */
+    if (so_rv == 0 && type == SOCK_STREAM && IS_LOOPBACK_ADDRESS(&sa)) {
+        NET_EnableFastTcpLoopbackConnect(fd);
+    }
+    
     rv = connect(fd, &sa.sa, sa_len);
     if (rv == SOCKET_ERROR) {
         int err = WSAGetLastError();


### PR DESCRIPTION
Building upon [JDK-8250521](https://bugs.openjdk.java.net/browse/JDK-8250521) which only added support for NIOSocketImpl (default), add support to PlainSocketImpl which can be selected as the implementation.

This is required for the backport to 11u where NIOSocketImpl doesn't exist and PlainSocketImpl is the default implementation

To test on windows run with -Djdk.net.usePlainSocketImpl

Before fix loopback timeouts:

- NioSocketImpl ~200ms
- PlainSocketImpl ~22200ms

After fix loopback timeouts:

- NioSocketImpl ~200ms
- PlainSocketImpl ~200ms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267256](https://bugs.openjdk.java.net/browse/JDK-8267256): Extend minimal retry for loopback connections on Windows to PlainSocketImpl


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/153.diff">https://git.openjdk.java.net/jdk17u/pull/153.diff</a>

</details>
