### PR TITLE
Backport 86a8e5524ddb5e25dab54b4f56cc1b9c27d0a4a6

### DIFF
--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -45,6 +45,11 @@ void VM_Version::initialize() {
   }
   FLAG_SET_DEFAULT(AllocatePrefetchDistance, 0);
 
+  // If lock diagnostics is needed, always call to runtime
+  if (DiagnoseSyncOnValueBasedClasses != 0) {
+    FLAG_SET_DEFAULT(UseHeavyMonitors, true);
+  }
+
   // Not implemented
   UNSUPPORTED_OPTION(CriticalJNINatives);
 }

--- a/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
@@ -47,8 +47,8 @@ public class SyncOnValueBasedClassTest {
         {"-Xcomp", "-XX:TieredStopAtLevel=1", "-XX:+UseBiasedLocking"},
         {"-Xcomp", "-XX:TieredStopAtLevel=1", "-XX:-UseBiasedLocking"},
         {"-Xcomp", "-XX:-TieredCompilation", "-XX:-UseBiasedLocking"},
-        {"-Xcomp", "-XX:-TieredCompilation", "-XX:+UseBiasedLocking", "-XX:+UseOptoBiasInlining"},
-        {"-Xcomp", "-XX:-TieredCompilation", "-XX:+UseBiasedLocking", "-XX:-UseOptoBiasInlining"}
+        {"-Xcomp", "-XX:-TieredCompilation", "-XX:+UseBiasedLocking", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:+UseOptoBiasInlining"},
+        {"-Xcomp", "-XX:-TieredCompilation", "-XX:+UseBiasedLocking", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-UseOptoBiasInlining"}
     };
 
     private static void initTestObjects() {


### PR DESCRIPTION
Unclean backport to fix Zero. The uncleanliness comes from the existing test shape in 17u, which uses `UseOptoBiasInlining` that is C2-specific flag, which Zero has no access to. In JDK 18, this was removed along with biased locking deprecation. I opted to fix the test in-place.

Additional testing:
 - [x] Linux x86_64 Zero passes the test now
 - [x] Linux x86_64 Server continues to pass the test