### PR TITLE
8273489: Zero: Handle UseHeavyMonitors on all monitorenter paths

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -332,13 +332,13 @@ int ZeroInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
     monitor = (BasicObjectLock*) istate->stack_base();
     oop lockee = monitor->obj();
     markWord disp = lockee->mark().set_unlocked();
-
     monitor->lock()->set_displaced_header(disp);
-    if (lockee->cas_set_mark(markWord::from_pointer(monitor), disp) != disp) {
-      if (thread->is_lock_owned((address) disp.clear_lock_bits().to_pointer())) {
+    bool call_vm = UseHeavyMonitors;
+    if (call_vm || lockee->cas_set_mark(markWord::from_pointer(monitor), disp) != disp) {
+      // Is it simple recursive case?
+      if (!call_vm && thread->is_lock_owned((address) disp.clear_lock_bits().to_pointer())) {
         monitor->lock()->set_displaced_header(markWord::from_pointer(NULL));
-      }
-      else {
+      } else {
         CALL_VM_NOCHECK(InterpreterRuntime::monitorenter(thread, monitor));
         if (HAS_PENDING_EXCEPTION)
           goto unwind_and_return;


### PR DESCRIPTION
Clean backport for more consistency in Zero implementation.

Additional testing:
 - [x] Linux x86_64 Zero builds fine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273489](https://bugs.openjdk.java.net/browse/JDK-8273489): Zero: Handle UseHeavyMonitors on all monitorenter paths


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/155.diff">https://git.openjdk.java.net/jdk17u/pull/155.diff</a>

</details>
