### PR TITLE
Backport 6ace805f8c69b273bf998f084f9651bc5bcd52b6

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class DoubleFlagWithIntegerValue {
   public static void testDoubleFlagWithValue(String value) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:G1ConcMarkStepDurationMillis=" + value, "-version");
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:SweeperThreshold=" + value, "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldNotContain("Improperly specified VM option");
     output.shouldHaveExitValue(0);


### PR DESCRIPTION
Clean backport to fix the test.

Additional testing:
  - [x] Linux x86_64 Minimal VM now passes the test