### PR TITLE
8273342: Null pointer dereference in classFileParser.cpp:2817

### DIFF
--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -55,7 +55,7 @@ Symbol* fieldDescriptor::generic_signature() const {
     }
   }
   assert(false, "should never happen");
-  return NULL;
+  return vmSymbols::void_signature(); // return a default value (for code analyzers)
 }
 
 bool fieldDescriptor::is_trusted_final() const {


### PR DESCRIPTION
Clean backport of JDK-8273342 to JDK-17u.  Tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273342](https://bugs.openjdk.java.net/browse/JDK-8273342): Null pointer dereference in classFileParser.cpp:2817


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/157.diff">https://git.openjdk.java.net/jdk17u/pull/157.diff</a>

</details>
