### PR TITLE
8268885: duplicate checkcast when destination type is not first type of intersection type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -784,7 +784,7 @@ public class TransTypes extends TreeTranslator {
             Type.IntersectionClassType ict = (Type.IntersectionClassType)originalTarget;
             for (Type c : ict.getExplicitComponents()) {
                 Type ec = erasure(c);
-                if (!types.isSameType(ec, tree.type)) {
+                if (!types.isSameType(ec, tree.type) && (!types.isSameType(ec, pt))) {
                     tree.expr = coerce(tree.expr, ec);
                 }
             }


### PR DESCRIPTION
I'd like to backport JDK-8268885 to 17u. It fixes duplicate checkcasts in javac.
The patch applies cleanly.
Tested with langtools tests, updated test fails without the fix, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268885](https://bugs.openjdk.java.net/browse/JDK-8268885): duplicate checkcast when destination type is not first type of intersection type


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/158.diff">https://git.openjdk.java.net/jdk17u/pull/158.diff</a>

</details>
