### PR TITLE
4819544: SwingSet2 JTable Demo throws NullPointerException

### DIFF
--- a/src/demo/share/jfc/SwingSet2/TableDemo.java
+++ b/src/demo/share/jfc/SwingSet2/TableDemo.java
@@ -549,7 +549,10 @@ public class TableDemo extends DemoModule {
             public int getRowCount() { return data.length;}
             public Object getValueAt(int row, int col) {return data[row][col];}
             public String getColumnName(int column) {return names[column];}
-            public Class<?> getColumnClass(int c) {return getValueAt(0, c).getClass();}
+            public Class<?> getColumnClass(int c) {
+                Object obj = getValueAt(0, c);
+                return obj != null ? obj.getClass() : Object.class;
+            }
             public boolean isCellEditable(int row, int col) {return col != 5;}
             public void setValueAt(Object aValue, int row, int column) { data[row][column] = aValue; }
          };


### PR DESCRIPTION
Clean backport of a SwingSet2 demo fix. Change it to demo code only.

Additional testing:

 - [x] checked manually with SwingSet2 that NPE does not happen

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4819544](https://bugs.openjdk.java.net/browse/JDK-4819544): SwingSet2 JTable Demo throws NullPointerException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/163.diff">https://git.openjdk.java.net/jdk17u/pull/163.diff</a>

</details>
