### PR TITLE
8268284: javax/swing/JComponent/7154030/bug7154030.java fails with "Exception: Failed to hide opaque button"

### DIFF
--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -57,7 +57,7 @@ public class bug7154030 {
 
     private static JButton button = null;
     private static JFrame frame;
-    private static int locx, locy, frw, frh;
+    private static volatile int locx, locy, frw, frh;
 
     public static void main(String[] args) throws Exception {
         try {
@@ -76,6 +76,7 @@ public class bug7154030 {
                     JDesktopPane desktop = new JDesktopPane();
                     button = new JButton("button");
                     frame = new JFrame();
+                    frame.setUndecorated(true);
 
                     button.setSize(200, 200);
                     button.setLocation(100, 100);
@@ -102,12 +103,14 @@ public class bug7154030 {
 
             Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
             Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
-            Rectangle bounds = frame.getBounds();
-            Insets insets = frame.getInsets();
-            locx = bounds.x + insets.left;
-            locy = bounds.y + insets.top;
-            frw = bounds.width - insets.left - insets.right;
-            frh = bounds.height - insets.top - insets.bottom;
+            SwingUtilities.invokeAndWait(() -> {
+                        Rectangle bounds = frame.getBounds();
+                        Insets insets = frame.getInsets();
+                        locx = bounds.x + insets.left;
+                        locy = bounds.y + insets.top;
+                        frw = bounds.width - insets.left - insets.right;
+                        frh = bounds.height - insets.top - insets.bottom;
+                    });
 
             BufferedImage fullScreen = robot.createScreenCapture(screen);
             Graphics g = fullScreen.getGraphics();


### PR DESCRIPTION
Clean backport of a Mac-specfic test fix. The change is test only.

Note, this test was added to problem list with [JDK-8271894](https://bugs.openjdk.java.net/browse/JDK-8271894) (in 17) and removed from problem list with [JDK-8271895](https://bugs.openjdk.java.net/browse/JDK-8271895) that is intended to be added as a follow up.

Additional testing:

 - [x] checked that test passes on Mac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ 8268284 is used in problem lists: [test/jdk/ProblemList.txt]

### Issue
 * [JDK-8268284](https://bugs.openjdk.java.net/browse/JDK-8268284): javax/swing/JComponent/7154030/bug7154030.java fails with "Exception: Failed to hide opaque button"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/164/head:pull/164` \
`$ git checkout pull/164`

Update a local copy of the PR: \
`$ git checkout pull/164` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 164`

View PR using the GUI difftool: \
`$ git pr show -t 164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/164.diff">https://git.openjdk.java.net/jdk17u/pull/164.diff</a>

</details>
