### PR TITLE
8274406: RunThese30M.java failed "assert(!LCA_orig->dominates(pred_block) || early->dominates(pred_block)) failed: early is high enough"

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1454,8 +1454,8 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       if (n_loop != loop_ctrl && n_loop->is_member(loop_ctrl)) {
         // n has a control input inside a loop but get_ctrl() is member of an outer loop. This could happen, for example,
         // for Div nodes inside a loop (control input inside loop) without a use except for an UCT (outside the loop).
-        // Rewire control of n to get_ctrl(n) to move it out of the loop, regardless if its input(s) are later sunk or not.
-        _igvn.replace_input_of(n, 0, n_ctrl);
+        // Rewire control of n to right outside of the loop, regardless if its input(s) are later sunk or not.
+        _igvn.replace_input_of(n, 0, place_outside_loop(n_ctrl, loop_ctrl));
       }
     }
     if (n_loop != _ltree_root && n->outcnt() > 1) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
@@ -29,9 +29,9 @@
  * @summary Sinking a data node used as divisor of a DivI node into a zero check UCT loses its pin outside the loop due to
  *          optimizing the CastII node away, resulting in a div by zero crash (SIGFPE) due to letting the DivI node floating
  *          back inside the loop.
- * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin -XX:-TieredCompilation
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin::* -XX:-TieredCompilation
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=4177789702 compiler.loopopts.TestSinkingDivisorLostPin
- * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin -XX:-TieredCompilation
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin::* -XX:-TieredCompilation
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM compiler.loopopts.TestSinkingDivisorLostPin
  */
 


### PR DESCRIPTION
Backport of [JDK-8274406](https://bugs.openjdk.java.net/browse/JDK-8274406). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274406](https://bugs.openjdk.java.net/browse/JDK-8274406): RunThese30M.java failed "assert(!LCA_orig->dominates(pred_block) || early->dominates(pred_block)) failed: early is high enough"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/173.diff">https://git.openjdk.java.net/jdk17u/pull/173.diff</a>

</details>
