### PR TITLE
Backport 74ffe12267cb3ae63072a06f50083fd0352d8049

### DIFF
--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -975,4 +975,5 @@ appendBootClassPath( JPLISAgent* agent,
     if (haveBasePath && parent != canonicalPath) {
         free(parent);
     }
+    free(paths);
 }


### PR DESCRIPTION
I'd like to backport JDK-8273575 to jdk17u.
The original patch applied cleanly.
The patch fixes a memory leak that should be fixed.