### PR TITLE
8273234: extended 'for' with expression of type tvar causes the compiler to crash

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1546,7 +1546,7 @@ public class Attr extends JCTree.Visitor {
                     // Check the return type of the method iterator().
                     // This is the bare minimum we need to verify to make sure code generation doesn't crash.
                     Symbol iterSymbol = rs.resolveInternalMethod(tree.pos(),
-                            loopEnv, exprType, names.iterator, List.nil(), List.nil());
+                            loopEnv, types.skipTypeVars(exprType, false), names.iterator, List.nil(), List.nil());
                     if (types.asSuper(iterSymbol.type.getReturnType(), syms.iteratorType.tsym) == null) {
                         log.error(tree.pos(),
                                 Errors.ForeachNotApplicableToType(exprType, Fragments.TypeReqArrayOrIterable));

--- a/test/langtools/tools/javac/foreach/ExprTypeIsTypeVariableTest.java
+++ b/test/langtools/tools/javac/foreach/ExprTypeIsTypeVariableTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8273234
+ * @summary extended 'for' with expression of type tvar causes the compiler to crash
+ * @compile ExprTypeIsTypeVariableTest.java
+ */
+
+import java.util.*;
+
+class ExprTypeIsTypeVariableTest {
+    abstract class A {}
+
+    abstract class ACD<E> implements Iterable<E> {
+        public Iterator<E> iterator() {
+            return null;
+        }
+    }
+
+    abstract class ALD<E> extends ACD<E> implements List<E> {}
+
+    abstract class ASP<NT extends A> extends ALD<A> {
+        <P extends ASP<NT>> void foo(P prod) {
+            for (A sym : prod) {}
+        }
+    }
+}


### PR DESCRIPTION
I'd like to backport this fix to 17u. It fixes regression in javac introduced in jdk17.
The patch applies cleanly.
Tested with langtools tests, new test fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273234](https://bugs.openjdk.java.net/browse/JDK-8273234): extended 'for' with expression of type tvar causes the compiler to crash


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/175.diff">https://git.openjdk.java.net/jdk17u/pull/175.diff</a>

</details>
