### PR TITLE
8272562: C2: assert(false) failed: Bad graph detected in build_loop_late

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1445,7 +1445,8 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       !n->is_MergeMem() &&
       !n->is_CMove() &&
       !is_raw_to_oop_cast && // don't extend live ranges of raw oops
-      n->Opcode() != Op_Opaque4) {
+      n->Opcode() != Op_Opaque4 &&
+      !n->is_Type()) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestSunkCastOnUnreachablePath.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSunkCastOnUnreachablePath.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8272562
+ * @summary C2: assert(false) failed: Bad graph detected in build_loop_late
+ *
+ * @run main/othervm -XX:CompileOnly=TestSunkCastOnUnreachablePath -XX:-TieredCompilation -Xbatch TestSunkCastOnUnreachablePath
+ *
+ */
+
+public class TestSunkCastOnUnreachablePath {
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 1000; i++) {
+            vMeth();
+        }
+    }
+
+    static int vMeth() {
+        int i2 = 3, iArr1[] = new int[200];
+
+        for (int i9 = 3; i9 < 100; i9++) {
+            try {
+                int i10 = (iArr1[i9 - 1]);
+                i2 = (i10 / i9);
+            } catch (ArithmeticException a_e) {
+            }
+        }
+        return i2;
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8272562](https://bugs.openjdk.java.net/browse/JDK-8272562). Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272562](https://bugs.openjdk.java.net/browse/JDK-8272562): C2: assert(false) failed: Bad graph detected in build_loop_late


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/176/head:pull/176` \
`$ git checkout pull/176`

Update a local copy of the PR: \
`$ git checkout pull/176` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 176`

View PR using the GUI difftool: \
`$ git pr show -t 176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/176.diff">https://git.openjdk.java.net/jdk17u/pull/176.diff</a>

</details>
