### PR TITLE
8274293: Build failure on macOS with Xcode 13.0 as vfork is deprecated

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -1885,7 +1885,11 @@ int os::fork_and_exec(const char* cmd, bool prefer_vfork) {
   // Use always vfork on AIX, since its safe and helps with analyzing OOM situations.
   // Otherwise leave it up to the caller.
   AIX_ONLY(prefer_vfork = true;)
+  #ifdef __APPLE__
+  pid = ::fork();
+  #else
   pid = prefer_vfork ? ::vfork() : ::fork();
+  #endif
 
   if (pid < 0) {
     // fork failed

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -444,7 +444,8 @@ static int copystrings(char *buf, int offset, const char * const *arg) {
 __attribute_noinline__
 #endif
 
-/* vfork(2) is deprecated on Solaris */
+/* vfork(2) is deprecated on Darwin */
+#ifndef __APPLE__
 static pid_t
 vforkChild(ChildStuff *c) {
     volatile pid_t resultPid;
@@ -463,6 +464,7 @@ vforkChild(ChildStuff *c) {
     assert(resultPid != 0);  /* childProcess never returns */
     return resultPid;
 }
+#endif
 
 static pid_t
 forkChild(ChildStuff *c) {
@@ -573,9 +575,11 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
 static pid_t
 startChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) {
     switch (c->mode) {
-/* vfork(2) is deprecated on Solaris */
+/* vfork(2) is deprecated on Darwin*/
+      #ifndef __APPLE__
       case MODE_VFORK:
         return vforkChild(c);
+      #endif
       case MODE_FORK:
         return forkChild(c);
       case MODE_POSIX_SPAWN:


### PR DESCRIPTION
Backport 252aaa9249d8979366b37d59487b5b039d923e35

bug link:https://bugs.openjdk.java.net/browse/JDK-8274293

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274293](https://bugs.openjdk.java.net/browse/JDK-8274293): Build failure on macOS with Xcode 13.0 as vfork is deprecated


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/182/head:pull/182` \
`$ git checkout pull/182`

Update a local copy of the PR: \
`$ git checkout pull/182` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 182`

View PR using the GUI difftool: \
`$ git pr show -t 182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/182.diff">https://git.openjdk.java.net/jdk17u/pull/182.diff</a>

</details>
