### PR TITLE
8274550: c2i entry barriers read int as long on PPC

### DIFF
--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -178,7 +178,7 @@ void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler *masm, Register tmp1,
   __ ld(tmp1_class_loader_data, in_bytes(InstanceKlass::class_loader_data_offset()), tmp1);
 
   // Fast path: If class loader is strong, the holder cannot be unloaded.
-  __ ld(tmp2, in_bytes(ClassLoaderData::keep_alive_offset()), tmp1_class_loader_data);
+  __ lwz(tmp2, in_bytes(ClassLoaderData::keep_alive_offset()), tmp1_class_loader_data);
   __ cmpdi(CCR0, tmp2, 0);
   __ bne(CCR0, skip_barrier);
 


### PR DESCRIPTION
Clean backport of JDK-8274550.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274550](https://bugs.openjdk.java.net/browse/JDK-8274550): c2i entry barriers read int as long on PPC


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/192/head:pull/192` \
`$ git checkout pull/192`

Update a local copy of the PR: \
`$ git checkout pull/192` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 192`

View PR using the GUI difftool: \
`$ git pr show -t 192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/192.diff">https://git.openjdk.java.net/jdk17u/pull/192.diff</a>

</details>
