### PR TITLE
8274773: [TESTBUG] UnsafeIntrinsicsTest intermittently fails on weak memory model platform

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -289,6 +289,7 @@ class Runner implements Runnable {
     private Node mergeImplLoad(Node startNode, Node expectedNext, Node head) {
         // Atomic load version
         Node temp = (Node) UNSAFE.getReference(startNode, offset);
+        UNSAFE.storeFence(); // Make all new Node fields visible to concurrent readers.
         startNode.setNext(head);
         return temp;
     }


### PR DESCRIPTION
Clean backport of JDK-8274773.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274773](https://bugs.openjdk.java.net/browse/JDK-8274773): [TESTBUG] UnsafeIntrinsicsTest intermittently fails on weak memory model platform


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/194.diff">https://git.openjdk.java.net/jdk17u/pull/194.diff</a>

</details>
