### PR TITLE
8275049: [ZGC] missing null check in ZNMethod::log_register

### DIFF
--- a/src/hotspot/share/gc/z/zNMethod.cpp
+++ b/src/hotspot/share/gc/z/zNMethod.cpp
@@ -126,8 +126,10 @@ void ZNMethod::log_register(const nmethod* nm) {
     oop* const begin = nm->oops_begin();
     oop* const end = nm->oops_end();
     for (oop* p = begin; p < end; p++) {
+      const oop o = Atomic::load(p); // C1 PatchingStub may replace it concurrently.
+      const char* external_name = (o == nullptr) ? "N/A" : o->klass()->external_name();
       log_oops.print("           Oop[" SIZE_FORMAT "] " PTR_FORMAT " (%s)",
-                     (p - begin), p2i(*p), (*p)->klass()->external_name());
+                     (p - begin), p2i(o), external_name);
     }
   }
 


### PR DESCRIPTION
Clean backport of JDK-8275049.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275049](https://bugs.openjdk.java.net/browse/JDK-8275049): [ZGC] missing null check in ZNMethod::log_register


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/195.diff">https://git.openjdk.java.net/jdk17u/pull/195.diff</a>

</details>
