### PR TITLE
Backport b870468bdc99938fbb19a41b0ede0a3e3769ace2

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1800,6 +1800,7 @@ public class Attr extends JCTree.Visitor {
                 }
                 addVars(c.stats, switchEnv.info.scope);
 
+                preFlow(c);
                 c.completesNormally = flow.aliveAfter(caseEnv, c, make);
 
                 prevBindings = c.caseKind == CaseTree.CaseKind.STATEMENT && c.completesNormally ? currentBindings
@@ -5914,6 +5915,8 @@ public class Attr extends JCTree.Visitor {
 
         @Override
         public void visitBindingPattern(JCBindingPattern that) {
+            initTypeIfNeeded(that);
+            initTypeIfNeeded(that.var);
             if (that.var.sym == null) {
                 that.var.sym = new BindingSymbol(0, that.var.name, that.var.type, syms.noSymbol);
                 that.var.sym.adr = 0;

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitchInfer.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitchInfer.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8206986 8254286
+ * @bug 8206986 8254286 8274347
  * @summary Check types inferred for switch expressions.
  * @compile/fail/ref=ExpressionSwitchInfer.out -XDrawDiagnostics ExpressionSwitchInfer.java
  */
@@ -83,4 +83,14 @@ public class ExpressionSwitchInfer {
     interface I1 extends I {}
     interface I2 extends I {}
 
+    void preflow(int i, int j) {
+        System.out.println(switch (i) {
+            case 1 -> switch (j) {
+                    case 1 -> "one and one";
+                    default -> "one and many";
+                };
+            case 2 -> "two";
+            default -> "many";
+        });
+    }
 }


### PR DESCRIPTION
I'd like to backport this fix to 17u. It fixes regression in javac introduced in jdk17.
The patch applies cleanly.
Tested with langtools tests, updated tests fail without the patch, pass with it.