### PR TITLE
8275131: Exceptions after a touchpad gesture on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -128,7 +128,7 @@ AWT_NS_WINDOW_IMPLEMENTATION
 
             // send up to the GestureHandler to recursively dispatch on the AWT event thread
             DECLARE_CLASS(jc_GestureHandler, "com/apple/eawt/event/GestureHandler");
-            DECLARE_METHOD(sjm_handleGestureFromNative, jc_GestureHandler,
+            DECLARE_STATIC_METHOD(sjm_handleGestureFromNative, jc_GestureHandler,
                             "handleGestureFromNative", "(Ljava/awt/Window;IDDDD)V");
             (*env)->CallStaticVoidMethod(env, jc_GestureHandler, sjm_handleGestureFromNative,
                                awtWindow, type, (jdouble)loc.x, (jdouble)loc.y, (jdouble)a, (jdouble)b);


### PR DESCRIPTION
Backport 8275131: Exceptions after a touchpad gesture on macOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275131](https://bugs.openjdk.java.net/browse/JDK-8275131): Exceptions after a touchpad gesture on macOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/199.diff">https://git.openjdk.java.net/jdk17u/pull/199.diff</a>

</details>
