### PR TITLE
8272114: Unused _last_state in osThread_windows

### DIFF
--- a/src/hotspot/os/windows/osThread_windows.hpp
+++ b/src/hotspot/os/windows/osThread_windows.hpp
@@ -34,7 +34,6 @@
   HANDLE _thread_handle;        // Win32 thread handle
   HANDLE _interrupt_event;      // Event signalled on thread interrupt for use by
                                 // Process.waitFor().
-  ThreadState _last_state;
 
  public:
   // The following will only apply in the Win32 implementation, and should only
@@ -57,12 +56,6 @@
     return false;
   }
 #endif // ASSERT
-
-  // This is a temporary fix for the thread states during
-  // suspend/resume until we throw away OSThread completely.
-  // NEEDS_CLEANUP
-  void set_last_state(ThreadState state)           { _last_state = state; }
-  ThreadState get_last_state()                     { return _last_state; }
 
  private:
   void pd_initialize();


### PR DESCRIPTION
Clean backport of the Windows-specific cleanup.

Additional testing:

 - [x] tier1 on Windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272114](https://bugs.openjdk.java.net/browse/JDK-8272114): Unused _last_state in osThread_windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/205.diff">https://git.openjdk.java.net/jdk17u/pull/205.diff</a>

</details>
