### PR TITLE
8275145: file.encoding system property has an incorrect value on Windows

### DIFF
--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,15 @@ Java_jdk_internal_util_SystemProps_00024Raw_platformProperties(JNIEnv *env, jcla
     PUTPROP(propArray, _path_separator_NDX, sprops->path_separator);
     PUTPROP(propArray, _line_separator_NDX, sprops->line_separator);
 
+#ifdef MACOSX
+    /*
+     * Since sun_jnu_encoding is now hard-coded to UTF-8 on Mac, we don't
+     * want to use it to overwrite file.encoding
+     */
     PUTPROP(propArray, _file_encoding_NDX, sprops->encoding);
+#else
+    PUTPROP(propArray, _file_encoding_NDX, sprops->sun_jnu_encoding);
+#endif
     PUTPROP(propArray, _sun_jnu_encoding_NDX, sprops->sun_jnu_encoding);
 
     /*


### PR DESCRIPTION
This PR is for a backport of the subject fix to jdk17u. The fix for jdk18 was applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275145](https://bugs.openjdk.java.net/browse/JDK-8275145): file.encoding system property has an incorrect value on Windows ⚠️ Issue is not open.


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/213/head:pull/213` \
`$ git checkout pull/213`

Update a local copy of the PR: \
`$ git checkout pull/213` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 213`

View PR using the GUI difftool: \
`$ git pr show -t 213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/213.diff">https://git.openjdk.java.net/jdk17u/pull/213.diff</a>

</details>
