### PR TITLE
8275104: IR framework does not handle client VM builds correctly

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/flag/FlagVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/flag/FlagVM.java
@@ -27,6 +27,7 @@ import compiler.lib.ir_framework.CompLevel;
 import compiler.lib.ir_framework.TestFramework;
 import compiler.lib.ir_framework.shared.TestFrameworkException;
 import compiler.lib.ir_framework.shared.TestRunException;
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import sun.hotspot.WhiteBox;
 
@@ -72,7 +73,7 @@ public class FlagVM {
     private static final boolean EXCLUDE_RANDOM = Boolean.getBoolean("ExcludeRandom");
     private static final boolean FLIP_C1_C2 = Boolean.getBoolean("FlipC1C2");
     private static final boolean REQUESTED_VERIFY_IR = Boolean.parseBoolean(System.getProperty("VerifyIR", "true"));
-    private static final boolean VERIFY_IR = REQUESTED_VERIFY_IR && USE_COMPILER && !EXCLUDE_RANDOM && !FLIP_C1_C2 && !TEST_C1;
+    private static final boolean VERIFY_IR = REQUESTED_VERIFY_IR && USE_COMPILER && !EXCLUDE_RANDOM && !FLIP_C1_C2 && !TEST_C1 && Platform.isServer();
 
     private static String[] getPrintFlags() {
         return new String[] {"-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions"};

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -74,8 +74,18 @@ public class TestVM {
     public static final int WARMUP_ITERATIONS = Integer.parseInt(System.getProperty("Warmup", "2000"));
 
     private static final boolean TIERED_COMPILATION = (Boolean)WHITE_BOX.getVMFlag("TieredCompilation");
-    private static final CompLevel TIERED_COMPILATION_STOP_AT_LEVEL = CompLevel.forValue(((Long)WHITE_BOX.getVMFlag("TieredStopAtLevel")).intValue());
-    public static final boolean TEST_C1 = TIERED_COMPILATION && TIERED_COMPILATION_STOP_AT_LEVEL.getValue() < CompLevel.C2.getValue();
+    private static final CompLevel TIERED_COMPILATION_STOP_AT_LEVEL;
+    private static final boolean CLIENT_VM = Platform.isClient();
+
+    static {
+        CompLevel level = CompLevel.forValue(((Long)WHITE_BOX.getVMFlag("TieredStopAtLevel")).intValue());
+        if (CLIENT_VM && level == CompLevel.C2) {
+            // No C2 available, use C1 level without profiling.
+            level = CompLevel.C1_SIMPLE;
+        }
+        TIERED_COMPILATION_STOP_AT_LEVEL = level;
+    }
+    public static final boolean TEST_C1 = (TIERED_COMPILATION && TIERED_COMPILATION_STOP_AT_LEVEL.getValue() < CompLevel.C2.getValue()) || CLIENT_VM;
 
     static final boolean XCOMP = Platform.isComp();
     static final boolean VERBOSE = Boolean.getBoolean("Verbose");
@@ -560,10 +570,13 @@ public class TestVM {
             // Use highest available compilation level by default (usually C2).
             compLevel = TIERED_COMPILATION_STOP_AT_LEVEL;
         }
-        if (!TIERED_COMPILATION && compLevel.getValue() < CompLevel.C2.getValue()) {
+        if (TEST_C1 && compLevel == CompLevel.C2) {
             return CompLevel.SKIP;
         }
-        if (TIERED_COMPILATION && compLevel.getValue() > TIERED_COMPILATION_STOP_AT_LEVEL.getValue()) {
+        if ((!TIERED_COMPILATION && !CLIENT_VM) && compLevel.getValue() < CompLevel.C2.getValue()) {
+            return CompLevel.SKIP;
+        }
+        if ((TIERED_COMPILATION || CLIENT_VM) && compLevel.getValue() > TIERED_COMPILATION_STOP_AT_LEVEL.getValue()) {
             return CompLevel.SKIP;
         }
         return compLevel;

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/IRExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/IRExample.java
@@ -95,8 +95,8 @@ public class IRExample {
     // Only apply this rule if the VM flag UseZGC is true
     @IR(applyIf = {"UseZGC", "true"}, failOn = IRNode.LOAD)
     // We can also use comparators (<, <=, >, >=, !=, =) to restrict the rules.
-    // This rule is only applied if the loop unroll limit is 10 or greater.
-    @IR(applyIf = {"LoopUnrollLimit", ">= 10"}, failOn = IRNode.LOAD)
+    // This rule is only applied if TypeProfileLevel is 100 or greater.
+    @IR(applyIf = {"TypeProfileLevel", ">= 100"}, failOn = IRNode.LOAD)
     public void goodFailOn() {
         iFld = 42; // No load, no loop, no store to iFld2, no store to class Foo
     }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompLevels.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompLevels.java
@@ -25,6 +25,7 @@ package ir_framework.tests;
 
 import compiler.lib.ir_framework.*;
 import compiler.lib.ir_framework.test.TestVM;
+import jdk.test.lib.Platform;
 
 import java.lang.reflect.Method;
 
@@ -57,10 +58,12 @@ public class TestCompLevels {
             }
         }
         TestFramework framework = new TestFramework(TestNoTiered.class);
-        framework.setDefaultWarmup(10).addFlags("-XX:-TieredCompilation").start();
-        framework = new TestFramework(TestNoTiered.class);
-        framework.setDefaultWarmup(10).addScenarios(new Scenario(0, "-XX:-TieredCompilation")).start();
-        framework = new TestFramework(TestStopAtLevel1.class);
+        if (!Platform.isClient()) {
+            framework.setDefaultWarmup(10).addFlags("-XX:-TieredCompilation").start();
+            framework = new TestFramework(TestNoTiered.class);
+            framework.setDefaultWarmup(10).addScenarios(new Scenario(0, "-XX:-TieredCompilation")).start();
+            framework = new TestFramework(TestStopAtLevel1.class);
+        }
         framework.setDefaultWarmup(10).addFlags("-XX:TieredStopAtLevel=1").start();
         framework = new TestFramework(TestStopAtLevel1.class);
         framework.setDefaultWarmup(10).addScenarios(new Scenario(0, "-XX:TieredStopAtLevel=1")).start();
@@ -119,7 +122,9 @@ class TestNoTiered {
 
     @Check(test = "level1")
     public void check1(TestInfo info) {
-        TestFramework.assertNotCompiled(info.getTest()); // Never compiled without C1
+        if (!Platform.isClient()) {
+            TestFramework.assertNotCompiled(info.getTest()); // Never compiled without C1
+        }
     }
 
     @Test(compLevel = CompLevel.C1_LIMITED_PROFILE)

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 
 /*
  * @test
- * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
+ * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler1.enabled & vm.compiler2.enabled & vm.flagless
  * @summary Test IR matcher with different default IR node regexes. Use -DPrintIREncoding.
  *          Normally, the framework should be called with driver.
  * @library /test/lib /

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestSanity.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestSanity.java
@@ -67,12 +67,12 @@ public class TestSanity {
         testFramework = new TestFramework();
         testFramework.addScenarios(sDefault).addScenarios(s1, s2).start();
         testFramework = new TestFramework();
-        testFramework.addHelperClasses(HelperA.class).addScenarios(sDefault).addFlags("-XX:+UseSuperWord").start();
+        testFramework.addHelperClasses(HelperA.class).addScenarios(sDefault).addFlags("-XX:+UseTLAB").start();
         testFramework = new TestFramework();
-        testFramework.addHelperClasses(HelperA.class).addFlags("-XX:+UseSuperWord", "-XX:+UseCompiler").addScenarios(sDefault)
+        testFramework.addHelperClasses(HelperA.class).addFlags("-XX:+UseTLAB", "-XX:+UseCompiler").addScenarios(sDefault)
                      .addHelperClasses(HelperB.class, HelperC.class).addScenarios(s1, s2).addFlags("-XX:+TieredCompilation").start();
         testFramework = new TestFramework();
-        testFramework.addHelperClasses(HelperA.class).addFlags("-XX:+UseSuperWord", "-XX:+UseCompiler").addScenarios(sDefault)
+        testFramework.addHelperClasses(HelperA.class).addFlags("-XX:+UseTLAB", "-XX:+UseCompiler").addScenarios(sDefault)
                      .addHelperClasses(HelperB.class, HelperC.class).addScenarios(s1, s2).setDefaultWarmup(200)
                      .addFlags("-XX:+TieredCompilation").start();
     }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestWithHelperClasses.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestWithHelperClasses.java
@@ -30,7 +30,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
- * @requires vm.flagless
+ * @requires vm.flagless & vm.compiler1.enabled & vm.compiler2.enabled
  * @summary Test the framework with helper classes.
  * @library /test/lib /
  * @run driver ir_framework.tests.TestWithHelperClasses


### PR DESCRIPTION
The patch applies clean. Low risk, only test changes. The modified test passed on linux-x64. With this patch and [backport of 8273965](https://github.com/openjdk/jdk17u/pull/186), all `test/hotspot/jtreg/testlibrary_tests/ir_framework` tests passed with and without compiler1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275104](https://bugs.openjdk.java.net/browse/JDK-8275104): IR framework does not handle client VM builds correctly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/214.diff">https://git.openjdk.java.net/jdk17u/pull/214.diff</a>

</details>
