### PR TITLE
8258465: Headless build fails due to missing X11 headers on linux

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -43,11 +43,9 @@ AC_DEFUN_ONCE([LIB_DETERMINE_DEPENDENCIES],
   if test "x$OPENJDK_TARGET_OS" = xwindows || test "x$OPENJDK_TARGET_OS" = xmacosx; then
     # No X11 support on windows or macosx
     NEEDS_LIB_X11=false
-  elif test "x$ENABLE_HEADLESS_ONLY" = xtrue; then
-    # No X11 support needed when building headless only
-    NEEDS_LIB_X11=false
   else
-    # All other instances need X11
+    # All other instances need X11, even if building headless only, libawt still
+    # needs X11 headers.
     NEEDS_LIB_X11=true
   fi
 


### PR DESCRIPTION
I'd like to backport JDK-8258465 to jdk17u.

The patch makes configuration script to look up for X11 header that are actually REQUIRED even for HEADLESS builds. That prevents build failure due to absent X11 headers

The original patch applied cleanly

Tested on 20.04 LTS with

- temporary rename your X11 include directory (usually /usr/include/X11)
- configure headless-only build with --enable-headless-only flag

EXPECTED result: configuration FAILS with

`configure: error: Could not find X11 libraries. You might be able to fix this by running 'sudo apt-get install libx11-dev libxext-dev libxrender-dev libxrandr-dev libxtst-dev libxt-dev'.`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258465](https://bugs.openjdk.java.net/browse/JDK-8258465): Headless build fails due to missing X11 headers on linux


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/215.diff">https://git.openjdk.java.net/jdk17u/pull/215.diff</a>

</details>
