### PR TITLE
8275302: unexpected compiler error: cast, intersection types and sealed

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1664,7 +1664,7 @@ public class Types {
                 && s.hasTag(CLASS) && s.tsym.kind.matches(Kinds.KindSelector.TYP)
                 && (t.tsym.isSealed() || s.tsym.isSealed())) {
             return (t.isCompound() || s.isCompound()) ?
-                    false :
+                    true :
                     !areDisjoint((ClassSymbol)t.tsym, (ClassSymbol)s.tsym);
         }
         return result;

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -1238,5 +1238,18 @@ public class SealedCompilationTests extends CompilationTestCase {
                 class Foo<X extends A & I> {}
                 """
         );
+        assertOK(
+                """
+                class Outer {
+                    abstract class Base {}
+                    interface Marker {}
+                    sealed class B extends Base {}
+                    final class C extends B implements Marker {}
+                    private <T extends Base & Marker> void test(T obj) {
+                        B b = (B) obj;
+                    }
+                }
+                """
+        );
     }
 }


### PR DESCRIPTION
I'd like to backport JDK-8275302 to 17u. It fixes unexpected javac error.
The patch applies cleanly.
Tested with langtools tests, updated test passes after applying the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275302](https://bugs.openjdk.java.net/browse/JDK-8275302): unexpected compiler error: cast, intersection types and sealed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/220/head:pull/220` \
`$ git checkout pull/220`

Update a local copy of the PR: \
`$ git checkout pull/220` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 220`

View PR using the GUI difftool: \
`$ git pr show -t 220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/220.diff">https://git.openjdk.java.net/jdk17u/pull/220.diff</a>

</details>
