### PR TITLE
8274848: LambdaMetaFactory::metafactory on REF_invokeSpecial impl method has incorrect behavior

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -26,6 +26,8 @@ package java.lang.invoke;
 
 import sun.invoke.util.Wrapper;
 
+import java.lang.reflect.Modifier;
+
 import static java.lang.invoke.MethodHandleInfo.*;
 import static sun.invoke.util.Wrapper.forPrimitiveType;
 import static sun.invoke.util.Wrapper.forWrapperType;
@@ -157,7 +159,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
                 // Classes compiled prior to dynamic nestmate support invoke a private instance
                 // method with REF_invokeSpecial. Newer classes use REF_invokeVirtual or
                 // REF_invokeInterface, and we can use that instruction in the lambda class.
-                if (targetClass == implClass) {
+                if (targetClass == implClass && Modifier.isPrivate(implInfo.getModifiers())) {
                     this.implKind = implClass.isInterface() ? REF_invokeInterface : REF_invokeVirtual;
                 } else {
                     this.implKind = REF_invokeSpecial;

--- a/test/jdk/java/lang/invoke/lambda/invokeSpecial/InvokeSpecialMethodTest.java
+++ b/test/jdk/java/lang/invoke/lambda/invokeSpecial/InvokeSpecialMethodTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8274848
+ * @run testng InvokeSpecialMethodTest
+ * @summary ensure REF_invokeSpecial on a non-private implementation method
+ *          behaves as if `super::m` is invoked regardless of its access flag
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+import static java.lang.invoke.MethodType.methodType;
+
+public class InvokeSpecialMethodTest {
+    static class MethodTest {
+        static final Lookup LOOKUP = MethodHandles.lookup();
+
+        public String m_public() {
+            return "test_public";
+        }
+
+        protected String m_protected() {
+            return "test_protected";
+        }
+
+        private String m_private() {
+            return "test_private";
+        }
+
+        public static class SubClass extends MethodTest {
+            @Override
+            public String m_public() {
+                return "subclass_public";
+            }
+
+            @Override
+            public String m_protected() {
+                return "subclass_protected";
+            }
+
+            public String m_private() {
+                return "subclass_private";
+            }
+        }
+
+        /*
+         * findSpecial with Test class as the special caller matching
+         * the factory type `StringFactory(Test)`
+         */
+        static MethodHandle mh(String name) {
+            try {
+                return LOOKUP.findSpecial(MethodTest.class, name, methodType(String.class), MethodTest.class);
+            } catch (NoSuchMethodException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        static final MethodHandle M_PUBLIC = mh("m_public");
+        static final MethodHandle M_PROTECTED = mh("m_protected");
+        static final MethodHandle M_PRIVATE = mh("m_private");
+    }
+
+    @FunctionalInterface
+    interface StringFactory {
+        String get();
+    }
+
+    @DataProvider
+    public Object[][] methodProvider() {
+        return new Object[][]{
+                {MethodTest.M_PUBLIC, "test_public"},
+                {MethodTest.M_PROTECTED, "test_protected"},
+                {MethodTest.M_PRIVATE, "test_private"}
+        };
+    }
+
+    @Test(dataProvider = "methodProvider")
+    void test(MethodHandle implMethod, String expected) throws Throwable {
+        testMetafactory(implMethod, expected);
+        testAltMetafactory(implMethod, expected);
+    }
+
+    static void testMetafactory(MethodHandle implMethod, String expected) throws Throwable {
+        CallSite cs = LambdaMetafactory.metafactory(MethodTest.LOOKUP, "get",
+                                                    methodType(StringFactory.class, MethodTest.class),
+                                                    methodType(String.class), implMethod, methodType(String.class));
+        MethodTest o = new MethodTest.SubClass();
+        StringFactory factory = (StringFactory) cs.dynamicInvoker().invokeExact(o);
+        String actual = factory.get();
+        Assert.assertEquals(actual, expected);
+    }
+
+    static void testAltMetafactory(MethodHandle implMethod, String expected) throws Throwable {
+        CallSite cs = LambdaMetafactory.altMetafactory(MethodTest.LOOKUP, "get",
+                                                       methodType(StringFactory.class, MethodTest.class),
+                                                       methodType(String.class), implMethod, methodType(String.class),
+                                                       LambdaMetafactory.FLAG_SERIALIZABLE);
+        MethodTest o = new MethodTest.SubClass();
+        StringFactory factory = (StringFactory) cs.dynamicInvoker().invokeExact(o);
+        String actual = factory.get();
+        Assert.assertEquals(actual, expected);
+    }
+}


### PR DESCRIPTION
This pull request contains a backport of commit 21da2183 from the openjdk/jdk repository.

The commit being backported was authored by Mandy Chung on 28 Oct 2021 and was reviewed by Paul Sandoz and Dan Smith.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274848](https://bugs.openjdk.java.net/browse/JDK-8274848): LambdaMetaFactory::metafactory on REF_invokeSpecial impl method has incorrect behavior


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/221.diff">https://git.openjdk.java.net/jdk17u/pull/221.diff</a>

</details>
