### PR TITLE
8272345: macos doesn't check `os::set_boot_path()` result

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -452,7 +452,9 @@ void os::init_system_properties_values() {
       }
     }
     Arguments::set_java_home(buf);
-    set_boot_path('/', ':');
+    if (!set_boot_path('/', ':')) {
+        vm_exit_during_initialization("Failed setting boot class path.", NULL);
+    }
   }
 
   // Where to look for native libraries.

--- a/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
@@ -25,16 +25,14 @@
 /*
  * @test
  * @summary Test that CDS still works when the JDK is moved to a new directory
+ * @bug 8272345
  * @requires vm.cds
- * @requires os.family == "linux"
+ * @comment This test doesn't work on Windows because it depends on symlinks
+ * @requires os.family != "windows"
  * @library /test/lib
  * @compile test-classes/Hello.java
  * @run driver MoveJDKTest
  */
-
-// This test works only on Linux because it depends on symlinks and the name of the hotspot DLL (libjvm.so).
-// It probably doesn't work on Windows.
-// TODO: change libjvm.so to libjvm.dylib on MacOS, before adding "@requires os.family == mac"
 
 import java.io.File;
 import java.nio.file.Files;
@@ -134,6 +132,7 @@ public class MoveJDKTest {
                 throw new RuntimeException("Cannot create directory: " + dst);
             }
         }
+        final String jvmLib = System.mapLibraryName("jvm");
         for (String child : src.list()) {
             if (child.equals(".") || child.equals("..")) {
                 continue;
@@ -145,7 +144,7 @@ public class MoveJDKTest {
                 throw new RuntimeException("Already exists: " + child_dst);
             }
             if (child_src.isFile()) {
-                if (child.equals("libjvm.so") || child.equals("java")) {
+                if (child.equals(jvmLib) || child.equals("java")) {
                     Files.copy(child_src.toPath(), /* copy data to -> */ child_dst.toPath());
                 } else {
                     Files.createSymbolicLink(child_dst.toPath(),  /* link to -> */ child_src.toPath());


### PR DESCRIPTION
Clean backport of a Mac-specific fix.

Additonal testing:

 - [x] checked that updated test fails (with a crash) on Mac without the patch
 - [x] checked that updated test passes on Max and Linux

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272345](https://bugs.openjdk.java.net/browse/JDK-8272345): macos doesn't check `os::set_boot_path()` result


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/225/head:pull/225` \
`$ git checkout pull/225`

Update a local copy of the PR: \
`$ git checkout pull/225` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 225`

View PR using the GUI difftool: \
`$ git pr show -t 225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/225.diff">https://git.openjdk.java.net/jdk17u/pull/225.diff</a>

</details>
