### PR TITLE
Backport 7728423f8a4cf2b60d9774405b18a28ee498f268

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -744,8 +744,6 @@ javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
 
-javax/swing/JComponent/7154030/bug7154030.java 8268284 macosx-x64
-
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all


### PR DESCRIPTION
Clean backport of the ProblemList.txt entry removal.

It seems to be required to be pushed first to proceed with #229 .
