### PR TITLE
8276201: Shenandoah: Race results degenerated GC to enter wrong entry point

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -113,8 +113,10 @@ void ShenandoahDegenGC::op_degenerated() {
       op_mark();
 
     case _degenerated_mark:
-      // No fallthrough. Continue mark, handed over from concurrent mark
-      if (_degen_point == ShenandoahDegenPoint::_degenerated_mark) {
+      // No fallthrough. Continue mark, handed over from concurrent mark if
+      // concurrent mark has yet completed
+      if (_degen_point == ShenandoahDegenPoint::_degenerated_mark &&
+          heap->is_concurrent_mark_in_progress()) {
         op_finish_mark();
       }
       assert(!heap->cancelled_gc(), "STW mark can not OOM");


### PR DESCRIPTION
A clean backport of Shenandoah specific bug. The patch fixes a subtle race condition that results degenerated GC to enter wrong degen entry.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276201](https://bugs.openjdk.java.net/browse/JDK-8276201): Shenandoah: Race results degenerated GC to enter wrong entry point


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/232/head:pull/232` \
`$ git checkout pull/232`

Update a local copy of the PR: \
`$ git checkout pull/232` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 232`

View PR using the GUI difftool: \
`$ git pr show -t 232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/232.diff">https://git.openjdk.java.net/jdk17u/pull/232.diff</a>

</details>
