### PR TITLE
8276572: Fake libsyslookup.so library causes tooling issues

### DIFF
--- a/src/jdk.incubator.foreign/share/native/libsyslookup/syslookup.c
+++ b/src/jdk.incubator.foreign/share/native/libsyslookup/syslookup.c
@@ -26,3 +26,8 @@
 // Note: the include below is not strictly required, as dependencies will be pulled using linker flags.
 // Adding at least one #include removes unwanted warnings on some platforms.
 #include <stdlib.h>
+
+// Simple dummy function so this library appears as a normal library to tooling.
+char* syslookup() {
+  return "syslookup";
+}


### PR DESCRIPTION
Change needed in 17u as well to unblock our builds of this LTS release. jdk17u-fix-request made on the original bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276572](https://bugs.openjdk.java.net/browse/JDK-8276572): Fake libsyslookup.so library causes tooling issues


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/233/head:pull/233` \
`$ git checkout pull/233`

Update a local copy of the PR: \
`$ git checkout pull/233` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 233`

View PR using the GUI difftool: \
`$ git pr show -t 233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/233.diff">https://git.openjdk.java.net/jdk17u/pull/233.diff</a>

</details>
