### PR TITLE
8276550: Use SHA256 hash in build.tools.depend.Depend

### DIFF
--- a/make/jdk/src/classes/build/tools/depend/Depend.java
+++ b/make/jdk/src/classes/build/tools/depend/Depend.java
@@ -102,7 +102,7 @@ public class Depend implements Plugin {
             private final MessageDigest apiHash;
             {
                 try {
-                    apiHash = MessageDigest.getInstance("MD5");
+                    apiHash = MessageDigest.getInstance("SHA-256");
                 } catch (NoSuchAlgorithmException ex) {
                     throw new IllegalStateException(ex);
                 }


### PR DESCRIPTION
Clean backport to allow FIPS-enabled boot JDKs.

Additional testing:
 - [x] Linux x86_64 fastdebug build passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276550](https://bugs.openjdk.java.net/browse/JDK-8276550): Use SHA256 hash in build.tools.depend.Depend


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/235.diff">https://git.openjdk.java.net/jdk17u/pull/235.diff</a>

</details>
