### PR TITLE
8274522: java/lang/management/ManagementFactory/MXBeanException.java test fails with Shenandoah

### DIFF
--- a/test/jdk/java/lang/management/ManagementFactory/MXBeanException.java
+++ b/test/jdk/java/lang/management/ManagementFactory/MXBeanException.java
@@ -27,7 +27,7 @@
  * @summary Check if a RuntimeException is wrapped by RuntimeMBeanException
  *          only once.
  *
- * @requires vm.gc != "Z"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @author  Mandy Chung
  *
  * @build MXBeanException


### PR DESCRIPTION
Clean backport to fix one of the tests with Shenandoah.

Additional testing:
 - [x] Linux x86_64 fastdebug, test is now skipped

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274522](https://bugs.openjdk.java.net/browse/JDK-8274522): java/lang/management/ManagementFactory/MXBeanException.java test fails with Shenandoah


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/237/head:pull/237` \
`$ git checkout pull/237`

Update a local copy of the PR: \
`$ git checkout pull/237` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 237`

View PR using the GUI difftool: \
`$ git pr show -t 237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/237.diff">https://git.openjdk.java.net/jdk17u/pull/237.diff</a>

</details>
