### PR TITLE
8274523: java/lang/management/MemoryMXBean/MemoryTest.java test should handle Shenandoah

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -26,7 +26,7 @@
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc != "Z"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @author  Mandy Chung
  *
  * @modules jdk.management
@@ -38,7 +38,7 @@
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc == "Z"
+ * @requires vm.gc == "Z" | vm.gc == "Shenandoah"
  * @author  Mandy Chung
  *
  * @modules jdk.management


### PR DESCRIPTION
Clean backport to fix another test for Shenandoah.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test now passes with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274523](https://bugs.openjdk.java.net/browse/JDK-8274523): java/lang/management/MemoryMXBean/MemoryTest.java test should handle Shenandoah


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/238.diff">https://git.openjdk.java.net/jdk17u/pull/238.diff</a>

</details>
