### PR TITLE
8271315: Redo: Nimbus JTree renderer properties persist across L&F changes

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusIcon.java
@@ -43,7 +43,7 @@ import java.awt.image.BufferedImage;
  * An icon that delegates to a painter.
  * @author rbair
  */
-class NimbusIcon implements SynthIcon {
+class NimbusIcon implements SynthIcon, UIResource {
     private int width;
     private int height;
     private String prefix;

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -27352,10 +27352,10 @@
          <contentMargins top="0" bottom="0" left="0" right="0"/>
          <style>
             <textForeground>
-               <matte red="0" green="0" blue="0" alpha="0" uiDefaultParentName="text" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="false"/>
+               <matte red="0" green="0" blue="0" alpha="0" uiDefaultParentName="text" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
             </textForeground>
             <textBackground>
-               <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusLightBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="false"/>
+               <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusLightBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
             </textBackground>
             <background>
                <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusLightBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0"/>
@@ -27379,10 +27379,10 @@
                    <insets top="2" left="0" bottom="1" right="5"/>
                </uiProperty>
                <uiProperty name="selectionForeground" type="COLOR">
-                  <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusSelectedText" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="false"/>
+                  <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusSelectedText" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
                </uiProperty>
                <uiProperty name="selectionBackground" type="COLOR">
-                  <matte red="57" green="105" blue="138" alpha="255" uiDefaultParentName="nimbusSelectionBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="false"/>
+                  <matte red="57" green="105" blue="138" alpha="255" uiDefaultParentName="nimbusSelectionBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
                </uiProperty>
                <uiProperty name="dropLineColor" type="COLOR">
                   <matte red="242" green="242" blue="242" alpha="255" uiDefaultParentName="nimbusFocus" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0" alphaOffset="0"/>
@@ -27621,7 +27621,9 @@
                <stateTypes/>
                <contentMargins top="0" bottom="0" left="0" right="0"/>
                <style>
-                  <textForeground/>
+                  <textForeground>
+                    <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusSelectedText" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
+                  </textForeground>
                   <textBackground/>
                   <background/>
                   <uiproperties/>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
@@ -29,6 +29,7 @@ import javax.swing.*;
 import javax.swing.plaf.*;
 import javax.swing.plaf.basic.*;
 import javax.swing.text.View;
+import javax.swing.tree.DefaultTreeCellRenderer;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.Insets;
@@ -207,8 +208,14 @@ public class SynthLabelUI extends BasicLabelUI implements SynthUI {
         Icon icon = (label.isEnabled()) ? label.getIcon() :
                                           label.getDisabledIcon();
 
-        g.setColor(context.getStyle().getColor(context,
-                                               ColorType.TEXT_FOREGROUND));
+        if (label instanceof DefaultTreeCellRenderer &&
+                label.getForeground() instanceof UIResource) {
+            g.setColor(label.getForeground());
+        } else {
+            g.setColor(context.getStyle().getColor(context,
+                    ColorType.TEXT_FOREGROUND));
+        }
+
         g.setFont(style.getFont(context));
         context.getStyle().getGraphicsUtils(context).paintText(
             context, g, label.getText(), icon,

--- a/test/jdk/javax/swing/plaf/nimbus/NimbusJTreeSelTextColor.java
+++ b/test/jdk/javax/swing/plaf/nimbus/NimbusJTreeSelTextColor.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8266510 8271315
+ * @summary  Verifies Nimbus JTree default tree cell renderer use selected text color
+ * @run main/manual NimbusJTreeSelTextColor
+ */
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.awt.Color;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.GridBagConstraints;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.UIManager;
+
+public class NimbusJTreeSelTextColor {
+
+    private static JFrame frame;
+    private static JTree tree;
+    private static DefaultTreeCellRenderer treeCellRenderer;
+    private static volatile CountDownLatch countDownLatch;
+    private static volatile boolean testResult;
+
+    private static final String INSTRUCTIONS = "INSTRUCTIONS:\n\n"
+            + "Verify selected text color is same as selected tree leaf icon color.\n "
+            + "If the color is same ie, white\n"
+            + "then press Pass otherwise press Fail.";
+
+    public static void main(String args[]) throws Exception{
+        countDownLatch = new CountDownLatch(1);
+
+        SwingUtilities.invokeAndWait(NimbusJTreeSelTextColor::createUI);
+        countDownLatch.await(5, TimeUnit.MINUTES);
+
+        if (!testResult) {
+            throw new RuntimeException("Selected text color not same as selected tree leaf icon color!");
+        }
+    }
+
+    private static void createUI() {
+        try {
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        JFrame mainFrame = new JFrame();
+        GridBagLayout layout = new GridBagLayout();
+        JPanel mainControlPanel = new JPanel(layout);
+        JPanel resultButtonPanel = new JPanel(layout);
+
+        GridBagConstraints gbc = new GridBagConstraints();
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.insets = new Insets(5, 15, 5, 15);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainControlPanel.add(createComponent(), gbc);
+
+        JTextArea instructionTextArea = new JTextArea();
+        instructionTextArea.setText(INSTRUCTIONS);
+        instructionTextArea.setEditable(false);
+        instructionTextArea.setBackground(Color.white);
+
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainControlPanel.add(instructionTextArea, gbc);
+
+        JButton passButton = new JButton("Pass");
+        passButton.setActionCommand("Pass");
+        passButton.addActionListener((ActionEvent e) -> {
+            testResult = true;
+            mainFrame.dispose();
+            countDownLatch.countDown();
+
+        });
+
+        JButton failButton = new JButton("Fail");
+        failButton.setActionCommand("Fail");
+        failButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                mainFrame.dispose();
+                countDownLatch.countDown();
+            }
+        });
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+
+        resultButtonPanel.add(passButton, gbc);
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        resultButtonPanel.add(failButton, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        mainControlPanel.add(resultButtonPanel, gbc);
+
+        mainFrame.add(mainControlPanel);
+        mainFrame.pack();
+
+        mainFrame.addWindowListener(new WindowAdapter() {
+
+            @Override
+            public void windowClosing(WindowEvent e) {
+                mainFrame.dispose();
+                countDownLatch.countDown();
+            }
+        });
+        mainFrame.setLocationRelativeTo(null);
+        mainFrame.setVisible(true);
+    }
+
+    private static JComponent createComponent() {
+        tree = new JTree();
+
+        treeCellRenderer =  new DefaultTreeCellRenderer();
+        tree.setRootVisible(true);
+        tree.setShowsRootHandles(true);
+
+        tree.setCellRenderer(treeCellRenderer);
+        tree.setSelectionRow(1);
+        return tree;
+    }
+}
+

--- a/test/jdk/javax/swing/plaf/nimbus/NimbusPropertiesDoNotImplUIResource.java
+++ b/test/jdk/javax/swing/plaf/nimbus/NimbusPropertiesDoNotImplUIResource.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.nimbus.NimbusLookAndFeel;
+import java.awt.Color;
+
+/**
+ * @test
+ * @bug 8271315
+ * @summary  Nimbus JTree renderer properties persist across L&F changes
+ * @key headful
+ * @run main NimbusPropertiesDoNotImplUIResource
+ */
+
+public class NimbusPropertiesDoNotImplUIResource {
+    private static final String[] defPropertyKeys = new String[] {
+            "Tree.leafIcon", "Tree.closedIcon",
+            "Tree.openIcon", "Tree.selectionForeground",
+            "Tree.textForeground", "Tree.selectionBackground",
+            "Tree.textBackground", "Tree.selectionBorderColor"};
+
+    private static String failedKeys;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.LookAndFeelInfo[] installedLookAndFeels;
+        installedLookAndFeels = UIManager.getInstalledLookAndFeels();
+
+        for (UIManager.LookAndFeelInfo LF : installedLookAndFeels) {
+            try {
+                UIManager.setLookAndFeel(LF.getClassName());
+                failedKeys = null;
+                for (String propertyKey : defPropertyKeys) {
+                    verifyProperty(propertyKey);
+                }
+                if (failedKeys != null) {
+                    throw new RuntimeException("JTree renderer Properties " +
+                            failedKeys + " are not instance of UIResource for "
+                            + LF.getClassName());
+                }
+            } catch (UnsupportedLookAndFeelException e) {
+                System.out.println("Note: LookAndFeel " + LF.getClassName()
+                        + " is not supported on this configuration");
+            }
+        }
+
+        // Check that both uiResource option true and false work for
+        // getDerivedColor method of NimbusLookAndFeel
+        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+        Color color1 = ((NimbusLookAndFeel)UIManager.getLookAndFeel())
+                .getDerivedColor("text", 0, 0, 0, 0, false);
+        if (color1 instanceof UIResource) {
+            throw new RuntimeException("color1 should not be instance of " +
+                    "UIResource");
+        }
+
+        Color color2 = ((NimbusLookAndFeel)UIManager.getLookAndFeel())
+                .getDerivedColor("text", 0, 0, 0, 0, true);
+        if (!(color2 instanceof UIResource)) {
+            throw new RuntimeException("color2 should be instance of " +
+                    "UIResource");
+        }
+
+    }
+
+    private static void verifyProperty(String propertyKey) {
+        Object property = UIManager.get(propertyKey);
+        if (property == null) {
+            return;
+        }
+        if (!(property instanceof UIResource)) {
+            if (failedKeys == null) {
+                failedKeys = ":" + propertyKey;
+            } else {
+                failedKeys += "," + propertyKey;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of a Swing fix. This is a follow-up to #140 .

Additional testing:

 - [x] checked that manual NimbusJTreeSelTextColor test passes (with and without the patch)
 - [x] checked that NimbusPropertiesDoNotImplUIResource test fails without the patch and passes with the patch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271315](https://bugs.openjdk.java.net/browse/JDK-8271315): Redo: Nimbus JTree renderer properties persist across L&F changes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/240/head:pull/240` \
`$ git checkout pull/240`

Update a local copy of the PR: \
`$ git checkout pull/240` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 240`

View PR using the GUI difftool: \
`$ git pr show -t 240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/240.diff">https://git.openjdk.java.net/jdk17u/pull/240.diff</a>

</details>
