### PR TITLE
8273450: Fix the copyright header of SVML files

### DIFF
--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_acos_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_acos_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_asin_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_asin_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_atan2_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_atan2_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_atan_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_atan_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_cbrt_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_cbrt_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_cos_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_cos_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_cosh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_cosh_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_exp_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_exp_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_expm1_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_expm1_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_hypot_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_hypot_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_log10_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_log10_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_log1p_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_log1p_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_log_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_log_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_pow_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_pow_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_sin_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_sin_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_sinh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_sinh_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_tan_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_tan_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_d_tanh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_d_tanh_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_acos_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_acos_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_asin_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_asin_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_atan2_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_atan2_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_atan_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_atan_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_cbrt_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_cbrt_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_cos_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_cos_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_cosh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_cosh_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_exp_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_exp_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_expm1_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_expm1_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_hypot_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_hypot_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_log10_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_log10_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_log1p_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_log1p_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_log_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_log_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_pow_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_pow_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_sin_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_sin_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_sinh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_sinh_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_tan_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_tan_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libsvml/svml_s_tanh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libsvml/svml_s_tanh_linux_x86.S
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation.
+ * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_acos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_acos_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_asin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_asin_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_atan2_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_atan2_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_atan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_atan_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_cbrt_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_cbrt_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_cos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_cos_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_cosh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_cosh_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_exp_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_exp_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_expm1_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_expm1_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_hypot_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_hypot_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_log10_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_log10_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_log1p_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_log1p_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_log_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_log_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_pow_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_pow_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_sin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_sin_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_sinh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_sinh_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_tan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_tan_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_d_tanh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_d_tanh_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_acos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_acos_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_asin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_asin_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_atan2_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_atan2_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_atan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_atan_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_cbrt_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_cbrt_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_cos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_cos_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_cosh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_cosh_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_exp_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_exp_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_expm1_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_expm1_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_hypot_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_hypot_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_log10_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_log10_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_log1p_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_log1p_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_log_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_log_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_pow_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_pow_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_sin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_sin_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_sinh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_sinh_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_tan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_tan_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libsvml/svml_s_tanh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libsvml/svml_s_tanh_windows_x86.S
@@ -1,12 +1,14 @@
 ;
-; Copyright (c) 2018, 2021, Intel Corporation.
+; Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
 ; Intel Short Vector Math Library (SVML) Source Code
 ;
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Clean backport to fix copyright header of files. 

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273450](https://bugs.openjdk.java.net/browse/JDK-8273450): Fix the copyright header of SVML files


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/241/head:pull/241` \
`$ git checkout pull/241`

Update a local copy of the PR: \
`$ git checkout pull/241` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 241`

View PR using the GUI difftool: \
`$ git pr show -t 241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/241.diff">https://git.openjdk.java.net/jdk17u/pull/241.diff</a>

</details>
