### PR TITLE
8268927: Windows: link error: unresolved external symbol "int __cdecl convert_to_unicode(char const *,wchar_t * *)"

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -892,7 +892,7 @@ static SetThreadDescriptionFnPtr _SetThreadDescription = NULL;
 DEBUG_ONLY(static GetThreadDescriptionFnPtr _GetThreadDescription = NULL;)
 
 // forward decl.
-errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
+static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
 
 void os::set_native_thread_name(const char *name) {
 


### PR DESCRIPTION
Clean backport of the follow-up fix to [JDK-8238649](https://bugs.openjdk.java.net/browse/JDK-8238649) (#204).

I am unable to reproduce the linking problem locally.

Additional testing:

 - [x] fastdebug tier1 on Windows 2016

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268927](https://bugs.openjdk.java.net/browse/JDK-8268927): Windows: link error: unresolved external symbol "int __cdecl convert_to_unicode(char const *,wchar_t * *)"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/244/head:pull/244` \
`$ git checkout pull/244`

Update a local copy of the PR: \
`$ git checkout pull/244` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 244`

View PR using the GUI difftool: \
`$ git pr show -t 244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/244.diff">https://git.openjdk.java.net/jdk17u/pull/244.diff</a>

</details>
