### PR TITLE
8273416: C2: assert(false) failed: bad AD file after JDK-8252372 with UseSSE={0,1}

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -7189,6 +7189,7 @@ instruct castLL( eRegL dst ) %{
 %}
 
 instruct castFF( regF dst ) %{
+  predicate(UseSSE >= 2);
   match(Set dst (CastFF dst));
   format %{ "#castFF of $dst" %}
   ins_encode( /*empty encoding*/ );
@@ -7197,6 +7198,25 @@ instruct castFF( regF dst ) %{
 %}
 
 instruct castDD( regD dst ) %{
+  predicate(UseSSE >= 2);
+  match(Set dst (CastDD dst));
+  format %{ "#castDD of $dst" %}
+  ins_encode( /*empty encoding*/ );
+  ins_cost(0);
+  ins_pipe( empty );
+%}
+
+instruct castFF_PR( regFPR dst ) %{
+  predicate(UseSSE < 2);
+  match(Set dst (CastFF dst));
+  format %{ "#castFF of $dst" %}
+  ins_encode( /*empty encoding*/ );
+  ins_cost(0);
+  ins_pipe( empty );
+%}
+
+instruct castDD_PR( regDPR dst ) %{
+  predicate(UseSSE < 2);
   match(Set dst (CastDD dst));
   format %{ "#castDD of $dst" %}
   ins_encode( /*empty encoding*/ );

--- a/src/hotspot/share/opto/castnode.hpp
+++ b/src/hotspot/share/opto/castnode.hpp
@@ -140,7 +140,7 @@ public:
     init_class_id(Class_CastFF);
   }
   virtual int Opcode() const;
-  virtual uint ideal_reg() const { return Op_RegF; }
+  virtual uint ideal_reg() const { return in(1)->ideal_reg(); }
 };
 
 class CastDDNode: public ConstraintCastNode {
@@ -150,7 +150,7 @@ public:
     init_class_id(Class_CastDD);
   }
   virtual int Opcode() const;
-  virtual uint ideal_reg() const { return Op_RegD; }
+  virtual uint ideal_reg() const { return in(1)->ideal_reg(); }
 };
 
 class CastVVNode: public ConstraintCastNode {


### PR DESCRIPTION
Clean backport, fixes x86_32 failures. Would be followed with a few related fixes.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1` (clean)
 - [x] Linux x86_32 fastdebug `tier1` (some known failures)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273416](https://bugs.openjdk.java.net/browse/JDK-8273416): C2: assert(false) failed: bad AD file after JDK-8252372 with UseSSE={0,1}


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/245/head:pull/245` \
`$ git checkout pull/245`

Update a local copy of the PR: \
`$ git checkout pull/245` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 245`

View PR using the GUI difftool: \
`$ git pr show -t 245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/245.diff">https://git.openjdk.java.net/jdk17u/pull/245.diff</a>

</details>
