### PR TITLE
8275766: (tz) Update Timezone Data to 2021e

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2021c
+tzdata2021e

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -3409,11 +3409,6 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # shall [end] on Oct 24th 2020 at 01:00AM by delaying the clock by 60 minutes.
 # http://www.palestinecabinet.gov.ps/portal/Meeting/Details/51584
 
-# From Tim Parenti (2020-10-20):
-# Predict future fall transitions at 01:00 on the Saturday preceding October's
-# last Sunday (i.e., Sat>=24).  This is consistent with our predictions since
-# 2016, although the time of the change differed slightly in 2019.
-
 # From Pierre Cashon (2020-10-20):
 # The summer time this year started on March 28 at 00:00.
 # https://wafa.ps/ar_page.aspx?id=GveQNZa872839351758aGveQNZ
@@ -3425,6 +3420,17 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # From Paul Eggert (2019-04-10):
 # For now, guess spring-ahead transitions are at 00:00 on the Saturday
 # preceding March's last Sunday (i.e., Sat>=24).
+
+# From P Chan (2021-10-18):
+# http://wafa.ps/Pages/Details/34701
+# Palestine winter time will start from midnight 2021-10-29 (Thursday-Friday).
+#
+# From Heba Hemad, Palestine Ministry of Telecom & IT (2021-10-20):
+# ... winter time will begin in Palestine from Friday 10-29, 01:00 AM
+# by 60 minutes backwards.
+#
+# From Paul Eggert (2021-10-20):
+# Guess future fall transitions on October's last Friday at 01:00.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule EgyptAsia	1957	only	-	May	10	0:00	1:00	S
@@ -3461,7 +3467,8 @@ Rule Palestine	2016	2018	-	Oct	Sat>=24	1:00	0	-
 Rule Palestine	2019	only	-	Mar	29	0:00	1:00	S
 Rule Palestine	2019	only	-	Oct	Sat>=24	0:00	0	-
 Rule Palestine	2020	max	-	Mar	Sat>=24	0:00	1:00	S
-Rule Palestine	2020	max	-	Oct	Sat>=24	1:00	0	-
+Rule Palestine	2020	only	-	Oct	24	1:00	0	-
+Rule Palestine	2021	max	-	Oct	lastFri	1:00	0	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct

--- a/make/data/tzdata/australasia
+++ b/make/data/tzdata/australasia
@@ -408,9 +408,22 @@ Zone	Indian/Cocos	6:27:40	-	LMT	1900
 # "Minister for Employment, Parveen Bala says they had never thought of
 # stopping daylight saving. He says it was just to decide on when it should
 # start and end.  Bala says it is a short period..."
-# Since the end date is still in line with our ongoing predictions, assume for
-# now that the later-than-usual start date is a one-time departure from the
-# recent second Sunday in November pattern.
+#
+# From Tim Parenti (2021-10-11), per Jashneel Kumar (2021-10-11) and P Chan
+# (2021-10-12):
+# https://www.fiji.gov.fj/Media-Centre/Speeches/English/PM-BAINIMARAMA-S-COVID-19-ANNOUNCEMENT-10-10-21
+# https://www.fbcnews.com.fj/news/covid-19/curfew-moved-back-to-11pm/
+# In a 2021-10-10 speech concerning updated Covid-19 mitigation measures in
+# Fiji, prime minister Josaia Voreqe "Frank" Bainimarama announced the
+# suspension of DST for the 2021/2022 season: "Given that we are in the process
+# of readjusting in the midst of so many changes, we will also put Daylight
+# Savings Time on hold for this year. It will also make the reopening of
+# scheduled commercial air service much smoother if we don't have to be
+# concerned shifting arrival and departure times, which may look like a simple
+# thing but requires some significant logistical adjustments domestically and
+# internationally."
+# Assume for now that DST will resume with the recent pre-2020 rules for the
+# 2022/2023 season.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Fiji	1998	1999	-	Nov	Sun>=1	2:00	1:00	-
@@ -422,10 +435,11 @@ Rule	Fiji	2011	only	-	Mar	Sun>=1	3:00	0	-
 Rule	Fiji	2012	2013	-	Jan	Sun>=18	3:00	0	-
 Rule	Fiji	2014	only	-	Jan	Sun>=18	2:00	0	-
 Rule	Fiji	2014	2018	-	Nov	Sun>=1	2:00	1:00	-
-Rule	Fiji	2015	max	-	Jan	Sun>=12	3:00	0	-
+Rule	Fiji	2015	2021	-	Jan	Sun>=12	3:00	0	-
 Rule	Fiji	2019	only	-	Nov	Sun>=8	2:00	1:00	-
 Rule	Fiji	2020	only	-	Dec	20	2:00	1:00	-
-Rule	Fiji	2021	max	-	Nov	Sun>=8	2:00	1:00	-
+Rule	Fiji	2022	max	-	Nov	Sun>=8	2:00	1:00	-
+Rule	Fiji	2023	max	-	Jan	Sun>=12	3:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
 			12:00	Fiji	+12/+13

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -844,7 +844,7 @@ Zone	Europe/Andorra	0:06:04 -	LMT	1901
 # Shanks & Pottenger give 02:00, the BEV 00:00.  Go with the BEV,
 # and guess 02:00 for 1945-04-12.
 
-# From Alois Triendl (2019-07-22):
+# From Alois Treindl (2019-07-22):
 # In 1946 the end of DST was on Monday, 7 October 1946, at 3:00 am.
 # Shanks had this right.  Source: Die Weltpresse, 5. Oktober 1946, page 5.
 
@@ -1758,19 +1758,22 @@ Zone Atlantic/Reykjavik	-1:28	-	LMT	1908
 # advanced to sixty minutes later starting at hour two on 1944-04-02; ...
 # Starting at hour three on the date 1944-09-17 standard time will be resumed.
 #
-# From Alois Triendl (2019-07-02):
+# From Alois Treindl (2019-07-02):
 # I spent 6 Euros to buy two archive copies of Il Messaggero, a Roman paper,
 # for 1 and 2 April 1944.  The edition of 2 April has this note: "Tonight at 2
 # am, put forward the clock by one hour.  Remember that in the night between
 # today and Monday the 'ora legale' will come in force again."  That makes it
 # clear that in Rome the change was on Monday, 3 April 1944 at 2 am.
 #
-# From Paul Eggert (2016-10-27):
+# From Paul Eggert (2021-10-05):
 # Go with INRiM for DST rules, except as corrected by Inglis for 1944
 # for the Kingdom of Italy.  This is consistent with Renzo Baldini.
 # Model Rome's occupation by using C-Eur rules from 1943-09-10
 # to 1944-06-04; although Rome was an open city during this period, it
-# was effectively controlled by Germany.
+# was effectively controlled by Germany.  Using C-Eur is consistent
+# with Treindl's comment about Rome in April 1944, as the "Rule Italy"
+# lines during German occupation do not affect Europe/Rome
+# (though they do affect Europe/Malta).
 #
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Italy	1916	only	-	Jun	 3	24:00	1:00	S
@@ -2646,7 +2649,7 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # Although Shanks lists 1945-01-01 as the date for transition from
 # +01/+02 to +02/+03, more likely this is a placeholder.  Guess that
 # the transition occurred at 1945-04-10 00:00, which is about when
-# Königsberg surrendered to Soviet troops.  (Thanks to Alois Triendl.)
+# Königsberg surrendered to Soviet troops.  (Thanks to Alois Treindl.)
 
 # From Paul Eggert (2016-03-18):
 # The 1989 transition is from USSR act No. 227 (1989-03-14).

--- a/make/data/tzdata/northamerica
+++ b/make/data/tzdata/northamerica
@@ -999,7 +999,7 @@ Zone America/Indiana/Vincennes -5:50:07 - LMT	1883 Nov 18 12:09:53
 			-5:00	US	E%sT
 #
 # Perry County, Indiana, switched from eastern to central time in April 2006.
-# From Alois Triendl (2019-07-09):
+# From Alois Treindl (2019-07-09):
 # The Indianapolis News, Friday 27 October 1967 states that Perry County
 # returned to CST.  It went again to EST on 27 April 1969, as documented by the
 # Indianapolis star of Saturday 26 April.
@@ -1959,7 +1959,7 @@ Zone America/Swift_Current -7:11:20 -	LMT	1905 Sep
 
 # Alberta
 
-# From Alois Triendl (2019-07-19):
+# From Alois Treindl (2019-07-19):
 # There was no DST in Alberta in 1967... Calgary Herald, 29 April 1967.
 # 1969, no DST, from Edmonton Journal 18 April 1969
 #
@@ -2014,7 +2014,7 @@ Zone America/Edmonton	-7:33:52 -	LMT	1906 Sep
 #
 # From Paul Eggert (2019-07-25):
 # Shanks says Fort Nelson did not observe DST in 1946, unlike Vancouver.
-# Alois Triendl confirmed this on 07-22, citing the 1946-04-27 Vancouver Daily
+# Alois Treindl confirmed this on 07-22, citing the 1946-04-27 Vancouver Daily
 # Province.  He also cited the 1946-09-28 Victoria Daily Times, which said
 # that Vancouver, Victoria, etc. "change at midnight Saturday"; for now,
 # guess they meant 02:00 Sunday since 02:00 was common practice in Vancouver.

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -601,9 +601,8 @@ public final class ZoneInfoFile {
                     params[7] = 0;
                 } else {
                     // hacking: see comment above
-                    if (dom < 0 || dom >= 24 &&
-                                   !(zoneId.equals("Asia/Gaza") ||
-                                     zoneId.equals("Asia/Hebron"))) {
+                    // No need of hacking for Asia/Gaza and Asia/Hebron from tz2021e
+                    if (dom < 0 || dom >= 24) {
                         params[6] = -1;
                         params[7] = toCalendarDOW[dow];
                     } else {

--- a/src/java.base/share/classes/sun/util/resources/TimeZoneNames.java
+++ b/src/java.base/share/classes/sun/util/resources/TimeZoneNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -353,7 +353,7 @@ public final class TimeZoneNames extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -380,7 +380,9 @@ public final class TimeZoneNames extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -569,9 +571,9 @@ public final class TimeZoneNames extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville Time", "DDUT",
                                                         "Dumont-d'Urville Summer Time", "DDUST",
                                                         "Dumont-d'Urville Time", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Macquarie Island Standard Time", "MIST",
-                                                   "Macquarie Island Daylight Time", "MIDT",
-                                                   "Macquarie Island Time", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Mawson Time", "MAWT",
                                                 "Mawson Summer Time", "MAWST",
                                                 "Mawson Time", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_de.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_de.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_de extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_de extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_de extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville Zeit", "DDUT",
                                                         "Dumont-d'Urville Sommerzeit", "DDUST",
                                                         "Dumont-d'Urville Zeit", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Macquarieinsel Zeit", "MIST",
-                                                   "Macquarieinsel Sommerzeit", "MIST",
-                                                   "Macquarieinsel Zeit", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Mawson Zeit", "MAWT",
                                                 "Mawson Sommerzeit", "MAWST",
                                                 "Mawson Zeit", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_es.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_es.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_es extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_es extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_es extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Hora de Dumont-d'Urville", "DDUT",
                                                         "Hora de verano de Dumont-d'Urville", "DDUST",
                                                         "Hora de Dumont-d'Urville", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Hora de Isla Macquarie", "MIST",
-                                                   "Hora de verano de Isla Macquarie", "MIST",
-                                                   "Hora de Isla Macquarie", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Hora de Mawson", "MAWT",
                                                 "Hora de verano de Mawson", "MAWST",
                                                 "Hora de Mawson", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_fr.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_fr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_fr extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_fr extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_fr extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Heure de Dumont-d'Urville", "DDUT",
                                                         "Heure d'\u00e9t\u00e9 de Dumont-d'Urville", "DDUST",
                                                         "Heure de Dumont-d'Urville", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Heure de l'Ile Macquarie", "MIST",
-                                                   "Heure d'\u00E9t\u00E9 de l'Ile Macquarie", "MIST",
-                                                   "Heure de l'Ile Macquarie", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Heure de Mawson", "MAWT",
                                                 "Heure d'\u00e9t\u00e9 de Mawson", "MAWST",
                                                 "Heure de Mawson", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_it.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_it.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_it extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_it extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_it extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Ora di Dumont-d'Urville", "DDUT",
                                                         "Ora estiva di Dumont-d'Urville", "DDUST",
                                                         "Ora di Dumont-d'Urville", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Ora dell'Isola Macquarie", "MIST",
-                                                   "Ora estiva dell'Isola Macquarie", "MIST",
-                                                   "Ora dell'Isola Macquarie", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Ora di Mawson", "MAWT",
                                                 "Ora estiva di Mawson", "MAWST",
                                                 "Ora di Mawson", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ja.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ja.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_ja extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_ja extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_ja extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"\u30c7\u30e5\u30e2\u30f3\u30c7\u30e5\u30eb\u30f4\u30a3\u30eb\u6642\u9593", "DDUT",
                                                         "\u30c7\u30e5\u30e2\u30f3\u30c7\u30e5\u30eb\u30f4\u30a3\u30eb\u590f\u6642\u9593", "DDUST",
                                                         "\u30C7\u30E5\u30E2\u30F3\u30FB\u30C7\u30E5\u30EB\u30D3\u30EB\u6642\u9593", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"\u30DE\u30C3\u30B3\u30FC\u30EA\u30FC\u5CF6\u6642\u9593", "MIST",
-                                                   "\u30DE\u30C3\u30B3\u30FC\u30EA\u30FC\u5CF6\u590F\u6642\u9593", "MIST",
-                                                   "\u30DE\u30C3\u30B3\u30FC\u30EA\u30FC\u5CF6\u6642\u9593", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"\u30e2\u30fc\u30bd\u30f3\u6642\u9593", "MAWT",
                                                 "\u30e2\u30fc\u30bd\u30f3\u590f\u6642\u9593", "MAWST",
                                                 "\u30E2\u30FC\u30BD\u30F3\u6642\u9593", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ko.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ko.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_ko extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_ko extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_ko extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"\ub4a4\ubabd \ub4a4\ub974\ube4c \uc2dc\uac04", "DDUT",
                                                         "\ub4a4\ubabd \ub4a4\ub974\ube4c \uc77c\uad11\uc808\uc57d\uc2dc\uac04", "DDUST",
                                                         "\uB450\uBAAC\uD2B8\uC6B0\uB974\uBE4C \uD45C\uC900\uC2DC", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"\uB9E4\uCF70\uB9AC \uC12C \uD45C\uC900\uC2DC", "MIST",
-                                                   "\uB9E4\uCF70\uB9AC \uC12C \uC77C\uAD11 \uC808\uC57D \uC2DC\uAC04", "MIST",
-                                                   "\uB9E4\uCF70\uB9AC \uC12C \uD45C\uC900\uC2DC", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"\ubaa8\uc2a8 \uc2dc\uac04", "MAWT",
                                                 "\ubaa8\uc2a8 \uc77c\uad11\uc808\uc57d\uc2dc\uac04", "MAWST",
                                                 "\uB9C8\uC2A8 \uD45C\uC900\uC2DC", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_pt_BR.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_pt_BR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_pt_BR extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_pt_BR extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_pt_BR extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Fuso hor\u00e1rio de Dumont-d'Urville", "DDUT",
                                                         "Fuso hor\u00e1rio de ver\u00e3o de Dumont-d'Urville", "DDUST",
                                                         "Fuso Hor\u00E1rio de Dumont-d'Urville", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Fuso Hor\u00E1rio da Ilha de Macquarie", "MIST",
-                                                   "Fuso Hor\u00E1rio de Ver\u00E3o da Ilha de Macquarie", "MIST",
-                                                   "Fuso Hor\u00E1rio da Ilha de Macquarie", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Fuso hor\u00e1rio de Mawson", "MAWT",
                                                 "Fuso hor\u00e1rio de ver\u00e3o de Mawson", "MAWST",
                                                 "Hor\u00E1rio de Mawson", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_sv.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_sv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_sv extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_sv extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_sv extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville, normaltid", "DDUT",
                                                         "Dumont-d'Urville, sommartid", "DDUST",
                                                         "Dumont-d'Urville-tid", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Macquarie\u00F6n, normaltid", "MIST",
-                                                   "Macquarie\u00F6n, sommartid", "MIST",
-                                                   "Macquarie\u00F6n, normaltid", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Mawson, normaltid", "MAWT",
                                                 "Mawson, sommartid", "MAWST",
                                                 "Mawson-tid", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_CN.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_CN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_zh_CN extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_zh_CN extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_zh_CN extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville \u65f6\u95f4", "DDUT",
                                                         "Dumont-d'Urville \u590f\u4ee4\u65f6", "DDUST",
                                                         "Dumont-d'Urville \u65F6\u95F4", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"\u9EA6\u5938\u91CC\u5C9B\u65F6\u95F4", "MIST",
-                                                   "\u9EA6\u5938\u91CC\u5C9B\u590F\u4EE4\u65F6", "MIST",
-                                                   "\u9EA6\u5938\u91CC\u5C9B\u65F6\u95F4", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"\u83ab\u68ee\u65f6\u95f4", "MAWT",
                                                 "\u83ab\u68ee\u590f\u4ee4\u65f6", "MAWST",
                                                 "\u83AB\u68EE\u65F6\u95F4", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_TW.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_TW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_zh_TW extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_zh_TW extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_zh_TW extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville \u6642\u9593", "DDUT",
                                                         "Dumont-d'Urville \u590f\u4ee4\u6642\u9593", "DDUST",
                                                         "Dumont-d'Urville \u6642\u9593", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"\u9EA5\u5938\u5229\u5CF6\u6642\u9593", "MIST",
-                                                   "\u9EA5\u5938\u5229\u5CF6\u590F\u4EE4\u6642\u9593", "MIST",
-                                                   "\u9EA5\u5938\u5229\u5CF6\u6642\u9593", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"\u83ab\u68ee\u6642\u9593", "MAWT",
                                                 "\u83ab\u68ee\u590f\u4ee4\u6642\u9593", "MAWST",
                                                 "\u83AB\u68EE\u6642\u9593", "MAWT"}},


### PR DESCRIPTION
8275849: TestZoneInfo310.java fails with tzdata2021e
8276536: Update TimeZoneNames files to follow the changes made by JDK-8275766

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8275766](https://bugs.openjdk.java.net/browse/JDK-8275766): (tz) Update Timezone Data to 2021e ⚠️ Issue is not open.
 * [JDK-8275849](https://bugs.openjdk.java.net/browse/JDK-8275849): TestZoneInfo310.java fails with tzdata2021e ⚠️ Issue is not open.
 * [JDK-8276536](https://bugs.openjdk.java.net/browse/JDK-8276536): Update TimeZoneNames files to follow the changes made by JDK-8275766 ⚠️ Issue is not open.


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/252.diff">https://git.openjdk.java.net/jdk17u/pull/252.diff</a>

</details>
