### PR TITLE
8274521: jdk/jfr/event/gc/detailed/TestGCLockerEvent.java fails when other GC is selected

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCLockerEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCLockerEvent.java
@@ -26,6 +26,7 @@
  * @test TestGCLockerEvent
  * @key jfr
  * @requires vm.hasJFR
+ * @requires vm.gc.G1
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test still passes (default)
 - [x] Linux x86_64 fastdebug, affected test still passes (G1)
 - [x] Linux x86_64 fastdebug, affected test is now ignored (Shenandoah)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274521](https://bugs.openjdk.java.net/browse/JDK-8274521): jdk/jfr/event/gc/detailed/TestGCLockerEvent.java fails when other GC is selected


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/256/head:pull/256` \
`$ git checkout pull/256`

Update a local copy of the PR: \
`$ git checkout pull/256` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 256`

View PR using the GUI difftool: \
`$ git pr show -t 256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/256.diff">https://git.openjdk.java.net/jdk17u/pull/256.diff</a>

</details>
