### PR TITLE
8276846: JDK-8273416 is incomplete for UseSSE=1

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -7189,7 +7189,7 @@ instruct castLL( eRegL dst ) %{
 %}
 
 instruct castFF( regF dst ) %{
-  predicate(UseSSE >= 2);
+  predicate(UseSSE >= 1);
   match(Set dst (CastFF dst));
   format %{ "#castFF of $dst" %}
   ins_encode( /*empty encoding*/ );
@@ -7207,7 +7207,7 @@ instruct castDD( regD dst ) %{
 %}
 
 instruct castFF_PR( regFPR dst ) %{
-  predicate(UseSSE < 2);
+  predicate(UseSSE < 1);
   match(Set dst (CastFF dst));
   format %{ "#castFF of $dst" %}
   ins_encode( /*empty encoding*/ );


### PR DESCRIPTION
Clean backport to further fix C2 for x86_32.

Additional testing:
 - [x] Linux x86_32 fastdebug `tier1` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276846](https://bugs.openjdk.java.net/browse/JDK-8276846): JDK-8273416 is incomplete for UseSSE=1


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/260.diff">https://git.openjdk.java.net/jdk17u/pull/260.diff</a>

</details>
