### PR TITLE
8276105: C2: Conv(D|F)2(I|L)Nodes::Ideal should handle rounding correctly

### DIFF
--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -108,8 +108,10 @@ const Type* ConvD2INode::Value(PhaseGVN* phase) const {
 //------------------------------Ideal------------------------------------------
 // If converting to an int type, skip any rounding nodes
 Node *ConvD2INode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  if( in(1)->Opcode() == Op_RoundDouble )
-  set_req(1,in(1)->in(1));
+  if (in(1)->Opcode() == Op_RoundDouble) {
+    set_req(1, in(1)->in(1));
+    return this;
+  }
   return NULL;
 }
 
@@ -142,8 +144,10 @@ Node* ConvD2LNode::Identity(PhaseGVN* phase) {
 //------------------------------Ideal------------------------------------------
 // If converting to an int type, skip any rounding nodes
 Node *ConvD2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  if( in(1)->Opcode() == Op_RoundDouble )
-  set_req(1,in(1)->in(1));
+  if (in(1)->Opcode() == Op_RoundDouble) {
+    set_req(1, in(1)->in(1));
+    return this;
+  }
   return NULL;
 }
 
@@ -179,8 +183,10 @@ Node* ConvF2INode::Identity(PhaseGVN* phase) {
 //------------------------------Ideal------------------------------------------
 // If converting to an int type, skip any rounding nodes
 Node *ConvF2INode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  if( in(1)->Opcode() == Op_RoundFloat )
-  set_req(1,in(1)->in(1));
+  if (in(1)->Opcode() == Op_RoundFloat) {
+    set_req(1, in(1)->in(1));
+    return this;
+  }
   return NULL;
 }
 
@@ -206,8 +212,10 @@ Node* ConvF2LNode::Identity(PhaseGVN* phase) {
 //------------------------------Ideal------------------------------------------
 // If converting to an int type, skip any rounding nodes
 Node *ConvF2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  if( in(1)->Opcode() == Op_RoundFloat )
-  set_req(1,in(1)->in(1));
+  if (in(1)->Opcode() == Op_RoundFloat) {
+    set_req(1, in(1)->in(1));
+    return this;
+  }
   return NULL;
 }
 


### PR DESCRIPTION
Clean backport to improve C2 x86_32 reliability.

Additional testing:
 - [x] Linux x86_32 fastdebug `tier1` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276105](https://bugs.openjdk.java.net/browse/JDK-8276105): C2: Conv(D|F)2(I|L)Nodes::Ideal should handle rounding correctly


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/261/head:pull/261` \
`$ git checkout pull/261`

Update a local copy of the PR: \
`$ git checkout pull/261` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 261`

View PR using the GUI difftool: \
`$ git pr show -t 261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/261.diff">https://git.openjdk.java.net/jdk17u/pull/261.diff</a>

</details>
