### PR TITLE
8276205: Shenandoah: CodeCache_lock should always be held for initializing code cache iteration

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -355,15 +355,15 @@ ShenandoahCodeRootsIterator::ShenandoahCodeRootsIterator() :
         _par_iterator(CodeCache::heaps()),
         _table_snapshot(NULL) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at safepoint");
-  assert(!Thread::current()->is_Worker_thread(), "Should not be acquired by workers");
-  CodeCache_lock->lock_without_safepoint_check();
+  MutexLocker locker(CodeCache_lock, Mutex::_no_safepoint_check_flag);
   _table_snapshot = ShenandoahCodeRoots::table()->snapshot_for_iteration();
 }
 
 ShenandoahCodeRootsIterator::~ShenandoahCodeRootsIterator() {
+  MonitorLocker locker(CodeCache_lock, Mutex::_no_safepoint_check_flag);
   ShenandoahCodeRoots::table()->finish_iteration(_table_snapshot);
   _table_snapshot = NULL;
-  CodeCache_lock->unlock();
+  locker.notify_all();
 }
 
 void ShenandoahCodeRootsIterator::possibly_parallel_blobs_do(CodeBlobClosure *f) {


### PR DESCRIPTION
I would like to backport this Shenandoah specific fix to jdk17u.

This patch fixed the bug that not holding CodeCache_lock while initializing concurrent nmethod iterations, that can lead to miscount number of concurrent walker and result assertion failure.

The patch fixed a bug that prevents iterators from walking nmethod concurrently due to holding CodeCache_lock during the walk.

The original patch does not apply cleanly, due to context changes. But the patch is small and simple, conflicts can be easily resolved manually.


Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276205](https://bugs.openjdk.java.net/browse/JDK-8276205): Shenandoah: CodeCache_lock should always be held for initializing code cache iteration


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/262/head:pull/262` \
`$ git checkout pull/262`

Update a local copy of the PR: \
`$ git checkout pull/262` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 262`

View PR using the GUI difftool: \
`$ git pr show -t 262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/262.diff">https://git.openjdk.java.net/jdk17u/pull/262.diff</a>

</details>
