### PR TITLE
8233020: (fs) UnixFileSystemProvider should use StaticProperty.userDir().

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.FilePermission;
 import java.util.*;
 
+import jdk.internal.util.StaticProperty;
 import sun.nio.ch.ThreadPool;
 import sun.security.util.SecurityConstants;
 import static sun.nio.fs.UnixNativeDispatcher.*;
@@ -47,13 +48,11 @@ import static sun.nio.fs.UnixConstants.*;
 public abstract class UnixFileSystemProvider
     extends AbstractFileSystemProvider
 {
-    private static final String USER_DIR = "user.dir";
     private static final byte[] EMPTY_PATH = new byte[0];
     private final UnixFileSystem theFileSystem;
 
     public UnixFileSystemProvider() {
-        String userDir = System.getProperty(USER_DIR);
-        theFileSystem = newFileSystem(userDir);
+        theFileSystem = newFileSystem(StaticProperty.userDir());
     }
 
     UnixFileSystem theFileSystem() {


### PR DESCRIPTION
Clean backport of a minor fix to UnixFileSystemProvider.

Additional testing:

 - [x] ran jtreg:java/nio/file/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233020](https://bugs.openjdk.java.net/browse/JDK-8233020): (fs) UnixFileSystemProvider should use StaticProperty.userDir().


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/263/head:pull/263` \
`$ git checkout pull/263`

Update a local copy of the PR: \
`$ git checkout pull/263` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 263`

View PR using the GUI difftool: \
`$ git pr show -t 263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/263.diff">https://git.openjdk.java.net/jdk17u/pull/263.diff</a>

</details>
