### PR TITLE
8271308: (fc) FileChannel.transferTo() transfers no more than Integer.MAX_VALUE bytes in one call

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,9 @@ public class FileChannelImpl
     // Access to FileDescriptor internals
     private static final JavaIOFileDescriptorAccess fdAccess =
         SharedSecrets.getJavaIOFileDescriptorAccess();
+
+    // Maximum direct transfer size
+    private static final int MAX_DIRECT_TRANSFER_SIZE;
 
     // Used to make native read and write calls
     private final FileDispatcher nd;
@@ -622,18 +625,18 @@ public class FileChannelImpl
         return count - remaining;
     }
 
-    private long transferToArbitraryChannel(long position, int icount,
+    private long transferToArbitraryChannel(long position, long count,
                                             WritableByteChannel target)
         throws IOException
     {
         // Untrusted target: Use a newly-erased buffer
-        int c = Math.min(icount, TRANSFER_SIZE);
+        int c = (int)Math.min(count, TRANSFER_SIZE);
         ByteBuffer bb = ByteBuffer.allocate(c);
         long tw = 0;                    // Total bytes written
         long pos = position;
         try {
-            while (tw < icount) {
-                bb.limit(Math.min((int)(icount - tw), TRANSFER_SIZE));
+            while (tw < count) {
+                bb.limit((int)Math.min(count - tw, TRANSFER_SIZE));
                 int nr = read(bb, pos);
                 if (nr <= 0)
                     break;
@@ -672,22 +675,23 @@ public class FileChannelImpl
         long sz = size();
         if (position > sz)
             return 0;
-        int icount = (int)Math.min(count, Integer.MAX_VALUE);
-        if ((sz - position) < icount)
-            icount = (int)(sz - position);
 
+        if ((sz - position) < count)
+            count = (int)(sz - position);
+
+        // Attempt a direct transfer, if the kernel supports it, limiting
+        // the number of bytes according to which platform
+        int icount = (int)Math.min(count, MAX_DIRECT_TRANSFER_SIZE);
         long n;
-
-        // Attempt a direct transfer, if the kernel supports it
         if ((n = transferToDirectly(position, icount, target)) >= 0)
             return n;
 
         // Attempt a mapped transfer, but only to trusted channel types
-        if ((n = transferToTrustedChannel(position, icount, target)) >= 0)
+        if ((n = transferToTrustedChannel(position, count, target)) >= 0)
             return n;
 
         // Slow path for untrusted targets
-        return transferToArbitraryChannel(position, icount, target);
+        return transferToArbitraryChannel(position, count, target);
     }
 
     private long transferFromFileChannel(FileChannelImpl src,
@@ -1348,11 +1352,15 @@ public class FileChannelImpl
     private native long transferTo0(FileDescriptor src, long position,
                                     long count, FileDescriptor dst);
 
+    // Retrieves the maximum size of a transfer
+    private static native int maxDirectTransferSize0();
+
     // Caches fieldIDs
     private static native long initIDs();
 
     static {
         IOUtil.load();
         allocationGranularity = initIDs();
+        MAX_DIRECT_TRANSFER_SIZE = maxDirectTransferSize0();
     }
 }

--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -252,3 +252,12 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
 #endif
 }
 
+JNIEXPORT jint JNICALL
+Java_sun_nio_ch_FileChannelImpl_maxDirectTransferSize0(JNIEnv* env, jobject this)
+{
+#if defined(LINUX)
+    return 0x7ffff000; // 2,147,479,552 maximum for sendfile()
+#else
+    return java_lang_Integer_MAX_VALUE;
+#endif
+}

--- a/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,6 +145,9 @@ Java_sun_nio_ch_FileChannelImpl_unmap0(JNIEnv *env, jobject this,
     return 0;
 }
 
+// Integer.MAX_VALUE - 1 is the maximum transfer size for TransmitFile()
+#define MAX_TRANSMIT_SIZE (java_lang_Integer_MAX_VALUE - 1)
+
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
                                             jobject srcFD,
@@ -156,8 +159,8 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
     LARGE_INTEGER where;
     HANDLE src = (HANDLE)(handleval(env, srcFD));
     SOCKET dst = (SOCKET)(fdval(env, dstFD));
-    DWORD chunkSize = (count > java_lang_Integer_MAX_VALUE) ?
-        java_lang_Integer_MAX_VALUE : (DWORD)count;
+    DWORD chunkSize = (count > MAX_TRANSMIT_SIZE) ?
+        MAX_TRANSMIT_SIZE : (DWORD)count;
     BOOL result;
 
     where.QuadPart = position;
@@ -188,4 +191,11 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
         return IOS_THROWN;
     }
     return chunkSize;
+}
+
+
+JNIEXPORT jint JNICALL
+Java_sun_nio_ch_FileChannelImpl_maxDirectTransferSize0(JNIEnv* env, jobject this)
+{
+    return MAX_TRANSMIT_SIZE;
 }

--- a/test/jdk/java/nio/channels/FileChannel/Transfer2GPlus.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfer2GPlus.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8271308
+ * @summary Verify that transferTo() copies more than Integer.MAX_VALUE bytes
+ * @library .. /test/lib
+ * @build jdk.test.lib.Platform
+ * @run main Transfer2GPlus
+ */
+
+import java.io.File;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Platform;
+
+public class Transfer2GPlus {
+    private static final int LINUX_MAX_TRANSFER_SIZE = 0x7ffff000;
+
+    private static final long BASE   = (long)Integer.MAX_VALUE;
+    private static final int  EXTRA  = 1024;
+    private static final long LENGTH = BASE + EXTRA;
+
+    public static void main(String[] args) throws IOException {
+        Path src = Files.createTempFile("src", ".dat");
+        src.toFile().deleteOnExit();
+        byte[] b = createSrcFile(src);
+        testToFileChannel(src, b);
+        testToWritableByteChannel(src, b);
+    }
+
+    // Create a file of size LENGTH with EXTRA random bytes at offset BASE.
+    private static byte[] createSrcFile(Path src)
+        throws IOException {
+        RandomAccessFile raf = new RandomAccessFile(src.toString(), "rw");
+        raf.setLength(LENGTH);
+        raf.seek(BASE);
+        Random r = new Random(System.nanoTime());
+        byte[] b = new byte[EXTRA];
+        r.nextBytes(b);
+        raf.write(b);
+        return b;
+    }
+
+    // Exercises transferToDirectly() on Linux and transferToTrustedChannel()
+    // on macOS and Windows.
+    private static void testToFileChannel(Path src, byte[] expected)
+        throws IOException {
+        Path dst = Files.createTempFile("dst", ".dat");
+        dst.toFile().deleteOnExit();
+        try (FileChannel srcCh = FileChannel.open(src)) {
+            try (FileChannel dstCh = FileChannel.open(dst,
+                 StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+                long n;
+                if ((n = srcCh.transferTo(0, LENGTH, dstCh)) < LENGTH) {
+                    if (!Platform.isLinux())
+                        throw new RuntimeException("Transfer too small: " + n);
+
+                    if (n != 0x7ffff000)
+                        throw new RuntimeException("Unexpected transfer size: " + n);
+                    if ((n += srcCh.transferTo(n, LENGTH, dstCh)) != LENGTH)
+                        throw new RuntimeException("Unexpected total size: " + n);
+                }
+
+                if (dstCh.size() < LENGTH)
+                    throw new RuntimeException("Target file too small: " +
+                        dstCh.size() + " < " + LENGTH);
+
+                System.out.println("Transferred " + n + " bytes");
+
+                dstCh.position(BASE);
+                ByteBuffer bb = ByteBuffer.allocate(EXTRA);
+                dstCh.read(bb);
+                if (!Arrays.equals(bb.array(), expected))
+                    throw new RuntimeException("Unexpected values");
+            }
+        }
+    }
+
+    // Exercises transferToArbitraryChannel() on all platforms.
+    private static void testToWritableByteChannel(Path src, byte[] expected)
+        throws IOException {
+        File file = File.createTempFile("dst", ".dat");
+        file.deleteOnExit();
+        try (FileChannel srcCh = FileChannel.open(src)) {
+            // The FileOutputStream is wrapped so that newChannel() does not
+            // return a FileChannelImpl and so make a faster path be taken.
+            try (DataOutputStream stream =
+                new DataOutputStream(new FileOutputStream(file))) {
+                try (WritableByteChannel wbc = Channels.newChannel(stream)) {
+                    long n;
+                    if ((n = srcCh.transferTo(0, LENGTH, wbc)) < LENGTH)
+                        throw new RuntimeException("Too few bytes transferred: " +
+                            n + " < " + LENGTH);
+
+                    System.out.println("Transferred " + n + " bytes");
+
+                    RandomAccessFile raf = new RandomAccessFile(file, "r");
+                    raf.seek(BASE);
+                    byte[] b = new byte[EXTRA];
+                    raf.read(b);
+                    if (!Arrays.equals(b, expected))
+                        throw new RuntimeException("Unexpected values");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of the FileChannel fix.

Additional testing:

 - [x] checked that added test is failing without the patch
 - [x] ran jtreg:java/nio/channels/FileChannel on Linux, Windows and Mac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271308](https://bugs.openjdk.java.net/browse/JDK-8271308): (fc) FileChannel.transferTo() transfers no more than Integer.MAX_VALUE bytes in one call


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/265/head:pull/265` \
`$ git checkout pull/265`

Update a local copy of the PR: \
`$ git checkout pull/265` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 265`

View PR using the GUI difftool: \
`$ git pr show -t 265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/265.diff">https://git.openjdk.java.net/jdk17u/pull/265.diff</a>

</details>
