### PR TITLE
8276845: (fs) java/nio/file/spi/SetDefaultProvider.java fails on x86_32

### DIFF
--- a/test/jdk/java/nio/file/spi/TestProvider.java
+++ b/test/jdk/java/nio/file/spi/TestProvider.java
@@ -28,6 +28,7 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
+import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.net.URI;
 import java.io.IOException;
@@ -171,6 +172,16 @@ public class TestProvider extends FileSystemProvider {
     {
         Path delegate = theFileSystem.unwrap(file);
         return defaultProvider.newByteChannel(delegate, options, attrs);
+    }
+
+    @Override
+    public FileChannel newFileChannel(Path file,
+                                      Set<? extends OpenOption> options,
+                                      FileAttribute<?>... attrs)
+        throws IOException
+    {
+        Path delegate = theFileSystem.unwrap(file);
+        return defaultProvider.newFileChannel(delegate, options, attrs);
     }
 
     @Override


### PR DESCRIPTION
Clean backport to improve x86_32 test.

Additional testing:
 - [x] Affected test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276845](https://bugs.openjdk.java.net/browse/JDK-8276845): (fs) java/nio/file/spi/SetDefaultProvider.java fails on x86_32


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/269/head:pull/269` \
`$ git checkout pull/269`

Update a local copy of the PR: \
`$ git checkout pull/269` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 269`

View PR using the GUI difftool: \
`$ git pr show -t 269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/269.diff">https://git.openjdk.java.net/jdk17u/pull/269.diff</a>

</details>
