### PR TITLE
8275586: Zero: Simplify interpreter initialization

### DIFF
--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -47,4 +47,8 @@ void VM_Version::initialize() {
 
   // Not implemented
   UNSUPPORTED_OPTION(CriticalJNINatives);
+  UNSUPPORTED_OPTION(UseCompiler);
+#ifdef ASSERT
+  UNSUPPORTED_OPTION(CountCompiledCalls);
+#endif
 }

--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -68,14 +68,6 @@ void ZeroInterpreter::initialize_code() {
     ZeroInterpreterGenerator g(_code);
     if (PrintInterpreter) print();
   }
-
-  // Allow c++ interpreter to do one initialization now that switches are set, etc.
-  BytecodeInterpreter start_msg(BytecodeInterpreter::initialize);
-  if (JvmtiExport::can_post_interpreter_events()) {
-    BytecodeInterpreter::run<true>(&start_msg);
-  } else {
-    BytecodeInterpreter::run<false>(&start_msg);
-  }
 }
 
 void ZeroInterpreter::invoke_method(Method* method, address entry_point, TRAPS) {


### PR DESCRIPTION
Clean backport to improve Zero interpreter initialization and prepare for other clean Zero backports.

Additional testing:
 - [x] Linux x86_64 Zero build
 - [x]  Linux x86_64 Zero bootcycle-images

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275586](https://bugs.openjdk.java.net/browse/JDK-8275586): Zero: Simplify interpreter initialization


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/271.diff">https://git.openjdk.java.net/jdk17u/pull/271.diff</a>

</details>
