### PR TITLE
8276801: gc/stress/CriticalNativeStress.java fails intermittently with Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -111,7 +111,7 @@ void ShenandoahCodeRoots::initialize() {
 }
 
 void ShenandoahCodeRoots::register_nmethod(nmethod* nm) {
-  assert_locked_or_safepoint(CodeCache_lock);
+  assert(CodeCache_lock->owned_by_self(), "Must have CodeCache_lock held");
   _nmethod_table->register_nmethod(nm);
 }
 
@@ -121,7 +121,7 @@ void ShenandoahCodeRoots::unregister_nmethod(nmethod* nm) {
 }
 
 void ShenandoahCodeRoots::flush_nmethod(nmethod* nm) {
-  assert_locked_or_safepoint(CodeCache_lock);
+  assert(CodeCache_lock->owned_by_self(), "Must have CodeCache_lock held");
   _nmethod_table->flush_nmethod(nm);
 }
 


### PR DESCRIPTION
A clean backport of Shenandoah specific patch.

This is a followup backport of JDK-8276205 to fix a bug that causes updates to `nmethod` while concurrent walk is in progress.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276801](https://bugs.openjdk.java.net/browse/JDK-8276801): gc/stress/CriticalNativeStress.java fails intermittently with Shenandoah


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/272/head:pull/272` \
`$ git checkout pull/272`

Update a local copy of the PR: \
`$ git checkout pull/272` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 272`

View PR using the GUI difftool: \
`$ git pr show -t 272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/272.diff">https://git.openjdk.java.net/jdk17u/pull/272.diff</a>

</details>
