### PR TITLE
8276905: Use appropriate macosx_version_minimum value while compiling metal shaders

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -834,6 +834,19 @@ endif
 
 ################################################################################
 
+# MACOSX_METAL_VERSION_MIN specifies the lowest version of Macosx
+# that should be used to compile Metal shaders. We support Metal
+# pipeline only on Macosx >=10.14. For Macosx versions <10.14 even if
+# we enable Metal pipeline using -Dsun.java2d.metal=true, at
+# runtime we force it to use OpenGL pipeline. And MACOSX_VERSION_MIN
+# for aarch64 has always been >10.14 so we use continue to use
+# MACOSX_VERSION_MIN for aarch64.
+ifeq ($(OPENJDK_TARGET_CPU_ARCH), xaarch64)
+    MACOSX_METAL_VERSION_MIN=$(MACOSX_VERSION_MIN)
+else
+    MACOSX_METAL_VERSION_MIN=10.14.0
+endif
+
 ifeq ($(call isTargetOs, macosx), true)
   SHADERS_SRC := $(TOPDIR)/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/shaders.metal
   SHADERS_SUPPORT_DIR := $(SUPPORT_OUTPUTDIR)/native/java.desktop/libosxui
@@ -845,7 +858,9 @@ ifeq ($(call isTargetOs, macosx), true)
       DEPS := $(SHADERS_SRC), \
       OUTPUT_FILE := $(SHADERS_AIR), \
       SUPPORT_DIR := $(SHADERS_SUPPORT_DIR), \
-      COMMAND := $(METAL) -c -std=osx-metal2.0 -o $(SHADERS_AIR) $(SHADERS_SRC), \
+      COMMAND := $(METAL) -c -std=osx-metal2.0 \
+          -mmacosx-version-min=$(MACOSX_METAL_VERSION_MIN) \
+          -o $(SHADERS_AIR) $(SHADERS_SRC), \
   ))
 
   $(eval $(call SetupExecute, metallib_shaders, \


### PR DESCRIPTION
Clean backport to 17u.
Metal pipeline was introduced in JDK17 and this fix resolves deployment target issue and needed in JDK17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276905](https://bugs.openjdk.java.net/browse/JDK-8276905): Use appropriate macosx_version_minimum value while compiling metal shaders


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/273/head:pull/273` \
`$ git checkout pull/273`

Update a local copy of the PR: \
`$ git checkout pull/273` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 273`

View PR using the GUI difftool: \
`$ git pr show -t 273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/273.diff">https://git.openjdk.java.net/jdk17u/pull/273.diff</a>

</details>
