### PR TITLE
8277195 missing CAccessibility definition in [CommonComponentAccessibility accessibilityHitTest]

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -1085,6 +1085,7 @@ static jobject sAccessibilityClass = NULL;
     DECLARE_STATIC_METHOD_RETURN(jm_accessibilityHitTest, sjc_CAccessibility, "accessibilityHitTest",
                                  "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;", nil);
 
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
     // Make it into java screen coords
     point.y = [[[[self view] window] screen] frame].size.height - point.y;
 


### PR DESCRIPTION
A part of the fix JDK-8274381 has already been back ported to 17u, however after the fix JDK-8267385 the rest changes need to be back ported too. 

It's this chunk: 

- (id)accessibilityHitTest:(NSPoint)point 
{ 
    JNIEnv* env = [ThreadUtilities getJNIEnv]; 

+ GET_CACCESSIBILITY_CLASS_RETURN(nil);

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277195](https://bugs.openjdk.java.net/browse/JDK-8277195): missing CAccessibility definition in [CommonComponentAccessibility accessibilityHitTest]


### Reviewers
 * [Anton Tarasov](https://openjdk.java.net/census#ant) (@forantar - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/275/head:pull/275` \
`$ git checkout pull/275`

Update a local copy of the PR: \
`$ git checkout pull/275` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 275`

View PR using the GUI difftool: \
`$ git pr show -t 275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/275.diff">https://git.openjdk.java.net/jdk17u/pull/275.diff</a>

</details>
