### PR TITLE
8277029: JMM GetDiagnosticXXXInfo APIs should verify output array sizes

### DIFF
--- a/src/hotspot/share/include/jmm.h
+++ b/src/hotspot/share/include/jmm.h
@@ -333,7 +333,8 @@ typedef struct jmmInterface_1_ {
   void         (JNICALL *GetDiagnosticCommandArgumentsInfo)
                                                  (JNIEnv *env,
                                                   jstring commandName,
-                                                  dcmdArgInfo *infoArray);
+                                                  dcmdArgInfo *infoArray,
+                                                  jint count);
   jstring      (JNICALL *ExecuteDiagnosticCommand)
                                                  (JNIEnv *env,
                                                   jstring command);

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1996,7 +1996,7 @@ JVM_ENTRY(void, jmm_GetDiagnosticCommandInfo(JNIEnv *env, jobjectArray cmds,
 JVM_END
 
 JVM_ENTRY(void, jmm_GetDiagnosticCommandArgumentsInfo(JNIEnv *env,
-          jstring command, dcmdArgInfo* infoArray))
+          jstring command, dcmdArgInfo* infoArray, jint count))
   ResourceMark rm(THREAD);
   oop cmd = JNIHandles::resolve_external_guard(command);
   if (cmd == NULL) {
@@ -2020,10 +2020,12 @@ JVM_ENTRY(void, jmm_GetDiagnosticCommandArgumentsInfo(JNIEnv *env,
   }
   DCmdMark mark(dcmd);
   GrowableArray<DCmdArgumentInfo*>* array = dcmd->argument_info_array();
-  if (array->length() == 0) {
-    return;
+  const int num_args = array->length();
+  if (num_args != count) {
+    assert(false, "jmm_GetDiagnosticCommandArgumentsInfo count mismatch (%d vs %d)", count, num_args);
+    THROW_MSG(vmSymbols::java_lang_InternalError(), "jmm_GetDiagnosticCommandArgumentsInfo count mismatch");
   }
-  for (int i = 0; i < array->length(); i++) {
+  for (int i = 0; i < num_args; i++) {
     infoArray[i].name = array->at(i)->name();
     infoArray[i].description = array->at(i)->description();
     infoArray[i].type = array->at(i)->type();

--- a/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
+++ b/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
@@ -79,7 +79,7 @@ jobject getDiagnosticCommandArgumentInfoArray(JNIEnv *env, jstring command,
     return NULL;
   }
   jmm_interface->GetDiagnosticCommandArgumentsInfo(env, command,
-                                                   dcmd_arg_info_array);
+                                                   dcmd_arg_info_array, num_arg);
   dcmdArgInfoCls = (*env)->FindClass(env,
                                      "com/sun/management/internal/DiagnosticCommandArgumentInfo");
   POP_EXCEPTION_CHECK_AND_FREE(0, dcmd_arg_info_array);


### PR DESCRIPTION
Hi all,

this pull request contains a backport of commit b8d33a2a from the openjdk/jdk repository.

I'd like to backport this patch to jdk17 and jdk11. Most relevant this is for jdk11, to prevent difficult-to-spot downport errors early (the DCmd framework is different, which exposes authors of dcmd to surprising bugs - this downport helps prevent that).

Jdk17 downport mainly because it makes no sense to fix 11 and head and leave 17 as it is.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277029](https://bugs.openjdk.java.net/browse/JDK-8277029): JMM GetDiagnosticXXXInfo APIs should verify output array sizes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/276/head:pull/276` \
`$ git checkout pull/276`

Update a local copy of the PR: \
`$ git checkout pull/276` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 276`

View PR using the GUI difftool: \
`$ git pr show -t 276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/276.diff">https://git.openjdk.java.net/jdk17u/pull/276.diff</a>

</details>
