### PR TITLE
8274716: JDWP Spec: the description for the Dispose command confuses suspend with resume.

### DIFF
--- a/make/data/jdwp/jdwp.spec
+++ b/make/data/jdwp/jdwp.spec
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,9 +134,9 @@ JDWP "Java(tm) Debug Wire Protocol"
         "<ul>"
         "<li>All event requests are cancelled. "
         "<li>All threads suspended by the thread-level "
-        "<a href=\"#JDWP_ThreadReference_Resume\">resume</a> command "
+        "<a href=\"#JDWP_ThreadReference_Suspend\">suspend</a> command "
         "or the VM-level "
-        "<a href=\"#JDWP_VirtualMachine_Resume\">resume</a> command "
+        "<a href=\"#JDWP_VirtualMachine_Suspend\">suspend</a> command "
         "are resumed as many times as necessary for them to run. "
         "<li>Garbage collection is re-enabled in all cases where it was "
         "<a href=\"#JDWP_ObjectReference_DisableCollection\">disabled</a> "


### PR DESCRIPTION
Hi all,
this pull request contains a clean backport of commit 29dcbb72 from the openjdk/jdk repository.
The commit being backported was authored by Richard Reingruber on 7 Oct 2021 and was reviewed by Alan Bateman, Chris Plummer and Serguei Spitsyn.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274716](https://bugs.openjdk.java.net/browse/JDK-8274716): JDWP Spec: the description for the Dispose command confuses suspend with resume.


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/277/head:pull/277` \
`$ git checkout pull/277`

Update a local copy of the PR: \
`$ git checkout pull/277` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 277`

View PR using the GUI difftool: \
`$ git pr show -t 277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/277.diff">https://git.openjdk.java.net/jdk17u/pull/277.diff</a>

</details>
