### PR TITLE
8272170: Missing memory barrier when checking active state for regions

### DIFF
--- a/src/hotspot/share/gc/g1/g1CommittedRegionMap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CommittedRegionMap.inline.hpp
@@ -30,7 +30,7 @@
 #include "utilities/bitMap.inline.hpp"
 
 inline bool G1CommittedRegionMap::active(uint index) const {
-  return _active.at(index);
+  return _active.par_at(index);
 }
 
 inline bool G1CommittedRegionMap::inactive(uint index) const {


### PR DESCRIPTION
Hi all,

  please review this backport for JDK-8272170: Missing memory barrier when checking active state for regions from jdk/jdk.

This one-liner applies cleanly.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272170](https://bugs.openjdk.java.net/browse/JDK-8272170): Missing memory barrier when checking active state for regions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/278.diff">https://git.openjdk.java.net/jdk17u/pull/278.diff</a>

</details>
