### PR TITLE
8274383: JNI call of getAccessibleSelection on a wrong thread

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ComboBoxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ComboBoxAccessibility.m
@@ -35,6 +35,12 @@ static jmethodID sjm_getAccessibleName = NULL;
     GET_STATIC_METHOD_RETURN(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName", \
                      "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", ret);
 
+static jmethodID sjm_getAccessibleSelection = NULL;
+#define GET_ACCESSIBLESELECTION_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleSelection, sjc_CAccessibility, "getAccessibleSelection", \
+    "(Ljavax/accessibility/AccessibleContext;Ljava/awt/Component;)Ljavax/accessibility/AccessibleSelection;", ret);
+
 @implementation ComboBoxAccessibility
 
 // NSAccessibilityElement protocol methods
@@ -43,15 +49,21 @@ static jmethodID sjm_getAccessibleName = NULL;
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     jobject axContext = [self axContextWithEnv:env];
     if (axContext == NULL) return nil;
-    jclass axContextClass = (*env)->GetObjectClass(env, axContext);
-    DECLARE_METHOD_RETURN(jm_getAccessibleSelection, axContextClass, "getAccessibleSelection", "(I)Ljavax/accessibility/Accessible;", nil);
-    jobject axSelectedChild = (*env)->CallObjectMethod(env, axContext, jm_getAccessibleSelection, 0);
+    GET_ACCESSIBLESELECTION_METHOD_RETURN(nil);
+    jobject axSelection = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleSelection, axContext, self->fComponent);
     CHECK_EXCEPTION();
+    if (axSelection == NULL) {
+        return nil;
+    }
+    jclass axSelectionClass = (*env)->GetObjectClass(env, axSelection);
+    DECLARE_METHOD_RETURN(jm_getAccessibleSelection, axSelectionClass, "getAccessibleSelection", "(I)Ljavax/accessibility/Accessible;", nil);
+    jobject axSelectedChild = (*env)->CallObjectMethod(env, axSelection, jm_getAccessibleSelection, 0);
+    CHECK_EXCEPTION();
+    (*env)->DeleteLocalRef(env, axSelection);
     (*env)->DeleteLocalRef(env, axContext);
     if (axSelectedChild == NULL) {
         return nil;
     }
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
     GET_ACCESSIBLENAME_METHOD_RETURN(nil);
     jobject childName = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleName, axSelectedChild, fComponent);
     CHECK_EXCEPTION();


### PR DESCRIPTION
Hi all,

this pull request contains a backport of commit b36881fa from the openjdk/jdk repository.

The commit being backported was authored by Artem Semenov on 28 Sep 2021 and was reviewed by Alexander Zuev and Anton Tarasov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274383](https://bugs.openjdk.java.net/browse/JDK-8274383): JNI call of getAccessibleSelection on a wrong thread


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/280/head:pull/280` \
`$ git checkout pull/280`

Update a local copy of the PR: \
`$ git checkout pull/280` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 280`

View PR using the GUI difftool: \
`$ git pr show -t 280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/280.diff">https://git.openjdk.java.net/jdk17u/pull/280.diff</a>

</details>
