### PR TITLE
8271071: accessibility of a table on macOS lacks cell navigation

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -73,6 +73,7 @@ class CAccessible extends CFRetainedResource implements Accessible {
     private static native void menuItemSelected(long ptr);
     private static native void treeNodeExpanded(long ptr);
     private static native void treeNodeCollapsed(long ptr);
+    private static native void selectedCellsChanged(long ptr);
 
     private Accessible accessible;
 
@@ -126,6 +127,19 @@ class CAccessible extends CFRetainedResource implements Accessible {
                 } else if (name.compareTo(ACCESSIBLE_ACTIVE_DESCENDANT_PROPERTY) == 0 ) {
                     if (newValue instanceof AccessibleContext) {
                         activeDescendant = (AccessibleContext)newValue;
+                        if (newValue instanceof Accessible) {
+                            Accessible a = (Accessible)newValue;
+                            AccessibleContext ac = a.getAccessibleContext();
+                            if (ac !=  null) {
+                                Accessible p = ac.getAccessibleParent();
+                                if (p != null) {
+                                    AccessibleContext pac = p.getAccessibleContext();
+                                    if ((pac != null) && (pac.getAccessibleRole() == AccessibleRole.TABLE)) {
+                                        selectedCellsChanged(ptr);
+                                    }
+                                }
+                            }
+                        }
                     }
                 } else if (name.compareTo(ACCESSIBLE_STATE_PROPERTY) == 0) {
                     AccessibleContext thisAC = accessible.getAccessibleContext();

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CellAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CellAccessibility.m
@@ -53,6 +53,11 @@
     }
 }
 
+- (NSInteger)accessibilityIndex
+{
+    return self->fIndex;
+}
+
 - (NSRect)accessibilityFrame
 {
     return [super accessibilityFrame];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
@@ -57,6 +57,7 @@
 - (void)postTitleChanged;
 - (void)postTreeNodeExpanded;
 - (void)postTreeNodeCollapsed;
+- (void)postSelectedCellsChanged;
 - (BOOL)isEqual:(nonnull id)anObject;
 - (BOOL)isAccessibleWithEnv:(JNIEnv _Nonnull * _Nonnull)env forAccessible:(nonnull jobject)accessible;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -378,6 +378,12 @@ static jobject sAccessibilityClass = NULL;
     NSAccessibilityPostNotification([[self accessibilitySelectedRows] firstObject], NSAccessibilityRowCollapsedNotification);
 }
 
+- (void)postSelectedCellsChanged
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, NSAccessibilitySelectedCellsChangedNotification);
+}
+
 - (BOOL)isEqual:(id)anObject
 {
     if (![anObject isKindOfClass:[self class]]) return NO;
@@ -1225,6 +1231,22 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_treeNodeCollapsed
 {
     JNI_COCOA_ENTER(env);
         [ThreadUtilities performOnMainThread:@selector(postTreeNodeCollapsed)
+                         on:(CommonComponentAccessibility *)jlong_to_ptr(element)
+                         withObject:nil
+                         waitUntilDone:NO];
+    JNI_COCOA_EXIT(env);
+}
+
+/*
+ * Class:     sun_lwawt_macosx_CAccessible
+ * Method:    selectedCellsChanged
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_selectedCellsChanged
+  (JNIEnv *env, jclass jklass, jlong element)
+{
+    JNI_COCOA_ENTER(env);
+        [ThreadUtilities performOnMainThread:@selector(postSelectedCellsChanged)
                          on:(CommonComponentAccessibility *)jlong_to_ptr(element)
                          withObject:nil
                          waitUntilDone:NO];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableRowAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableRowAccessibility.m
@@ -142,4 +142,9 @@ static jmethodID jm_getChildrenAndRoles = NULL;
         return NSMakeRect(point.x, point.y, width, height);
 }
 
+- (BOOL)isAccessibilityOrderedByRow
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
Hi all,

this pull request contains a backport of commit c0f3e1d6 from the openjdk/jdk repository.

The commit being backported was authored by Artem Semenov on 15 Oct 2021 and was reviewed by Anton Tarasov, Alexander Zuev and Pankaj Bansal.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271071](https://bugs.openjdk.java.net/browse/JDK-8271071): accessibility of a table on macOS lacks cell navigation


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/281.diff">https://git.openjdk.java.net/jdk17u/pull/281.diff</a>

</details>
