### PR TITLE
8275703: System.loadLibrary fails on Big Sur for libraries hidden from filesystem

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -87,8 +87,9 @@ ifeq ($(call isTargetOs, macosx), true)
       -framework Cocoa -framework SystemConfiguration
 else
   BUILD_JDK_JTREG_EXCLUDE += libTestMainKeyWindow.m
-  BUILD_JDK_JTREG_EXCLUDE += exeJniInvocationTest.c
   BUILD_JDK_JTREG_EXCLUDE += libTestDynamicStore.m
+  BUILD_JDK_JTREG_EXCLUDE += exeJniInvocationTest.c
+  BUILD_JDK_JTREG_EXCLUDE += exeLibraryCache.c
 endif
 
 ifeq ($(call isTargetOs, linux), true)

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -151,7 +151,7 @@ JNIEXPORT jboolean JNICALL
 JVM_IsUseContainerSupport(void);
 
 JNIEXPORT void * JNICALL
-JVM_LoadLibrary(const char *name);
+JVM_LoadLibrary(const char *name, jboolean throwException);
 
 JNIEXPORT void JNICALL
 JVM_UnloadLibrary(void * handle);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3357,7 +3357,7 @@ JVM_END
 
 // Library support ///////////////////////////////////////////////////////////////////////////
 
-JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name))
+JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name, jboolean throwException))
   //%note jvm_ct
   char ebuf[1024];
   void *load_result;
@@ -3366,18 +3366,23 @@ JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name))
     load_result = os::dll_load(name, ebuf, sizeof ebuf);
   }
   if (load_result == NULL) {
-    char msg[1024];
-    jio_snprintf(msg, sizeof msg, "%s: %s", name, ebuf);
-    // Since 'ebuf' may contain a string encoded using
-    // platform encoding scheme, we need to pass
-    // Exceptions::unsafe_to_utf8 to the new_exception method
-    // as the last argument. See bug 6367357.
-    Handle h_exception =
-      Exceptions::new_exception(thread,
-                                vmSymbols::java_lang_UnsatisfiedLinkError(),
-                                msg, Exceptions::unsafe_to_utf8);
+    if (throwException) {
+      char msg[1024];
+      jio_snprintf(msg, sizeof msg, "%s: %s", name, ebuf);
+      // Since 'ebuf' may contain a string encoded using
+      // platform encoding scheme, we need to pass
+      // Exceptions::unsafe_to_utf8 to the new_exception method
+      // as the last argument. See bug 6367357.
+      Handle h_exception =
+        Exceptions::new_exception(thread,
+                                  vmSymbols::java_lang_UnsatisfiedLinkError(),
+                                  msg, Exceptions::unsafe_to_utf8);
 
-    THROW_HANDLE_0(h_exception);
+      THROW_HANDLE_0(h_exception);
+    } else {
+      log_info(library)("Failed to load library %s", name);
+      return load_result;
+    }
   }
   log_info(library)("Loaded library %s, handle " INTPTR_FORMAT, name, p2i(load_result));
   return load_result;

--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -53,7 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * will fail.
  */
 public final class NativeLibraries {
-
+    private static final boolean loadLibraryOnlyIfPresent = ClassLoaderHelper.loadLibraryOnlyIfPresent();
     private final Map<String, NativeLibraryImpl> libraries = new ConcurrentHashMap<>();
     private final ClassLoader loader;
     // caller, if non-null, is the fromClass parameter for NativeLibraries::loadLibrary
@@ -142,7 +142,8 @@ public final class NativeLibraries {
     }
 
     /*
-     * Load a native library from the given file.  Returns null if file does not exist.
+     * Load a native library from the given file.  Returns null if the given
+     * library is determined to be non-loadable, which is system-dependent.
      *
      * @param fromClass the caller class calling System::loadLibrary
      * @param file the path of the native library
@@ -155,14 +156,17 @@ public final class NativeLibraries {
         boolean isBuiltin = (name != null);
         if (!isBuiltin) {
             name = AccessController.doPrivileged(new PrivilegedAction<>() {
-                public String run() {
-                    try {
-                        return file.exists() ? file.getCanonicalPath() : null;
-                    } catch (IOException e) {
-                        return null;
+                    public String run() {
+                        try {
+                            if (loadLibraryOnlyIfPresent && !file.exists()) {
+                                return null;
+                            }
+                            return file.getCanonicalPath();
+                        } catch (IOException e) {
+                            return null;
+                        }
                     }
-                }
-            });
+                });
             if (name == null) {
                 return null;
             }
@@ -381,7 +385,7 @@ public final class NativeLibraries {
                 throw new InternalError("Native library " + name + " has been loaded");
             }
 
-            return load(this, name, isBuiltin, isJNI);
+            return load(this, name, isBuiltin, isJNI, loadLibraryOnlyIfPresent);
         }
     }
 
@@ -461,7 +465,9 @@ public final class NativeLibraries {
 
     // JNI FindClass expects the caller class if invoked from JNI_OnLoad
     // and JNI_OnUnload is NativeLibrary class
-    private static native boolean load(NativeLibraryImpl impl, String name, boolean isBuiltin, boolean isJNI);
+    private static native boolean load(NativeLibraryImpl impl, String name,
+                                       boolean isBuiltin, boolean isJNI,
+                                       boolean throwExceptionIfFail);
     private static native void unload(String name, boolean isBuiltin, boolean isJNI, long handle);
     private static native String findBuiltinLib(String name);
     private static native long findEntry0(NativeLibraryImpl lib, String name);

--- a/src/java.base/share/native/libjava/NativeLibraries.c
+++ b/src/java.base/share/native/libjava/NativeLibraries.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,8 @@ static void *findJniFunction(JNIEnv *env, void *handle,
  */
 JNIEXPORT jboolean JNICALL
 Java_jdk_internal_loader_NativeLibraries_load
-  (JNIEnv *env, jobject this, jobject lib, jstring name, jboolean isBuiltin, jboolean isJNI)
+  (JNIEnv *env, jobject this, jobject lib, jstring name,
+   jboolean isBuiltin, jboolean isJNI, jboolean throwExceptionIfFail)
 {
     const char *cname;
     jint jniVersion;
@@ -127,7 +128,7 @@ Java_jdk_internal_loader_NativeLibraries_load
     cname = JNU_GetStringPlatformChars(env, name, 0);
     if (cname == 0)
         return JNI_FALSE;
-    handle = isBuiltin ? procHandle : JVM_LoadLibrary(cname);
+    handle = isBuiltin ? procHandle : JVM_LoadLibrary(cname, throwExceptionIfFail);
     if (isJNI) {
         if (handle) {
             JNI_OnLoad_t JNI_OnLoad;

--- a/src/java.base/unix/classes/jdk/internal/loader/ClassLoaderHelper.java
+++ b/src/java.base/unix/classes/jdk/internal/loader/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,14 @@ import java.util.ArrayList;
 class ClassLoaderHelper {
 
     private ClassLoaderHelper() {}
+
+    /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return true;
+    }
 
     /**
      * Returns an alternate path name for the given file

--- a/src/java.base/windows/classes/jdk/internal/loader/ClassLoaderHelper.java
+++ b/src/java.base/windows/classes/jdk/internal/loader/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,14 @@ import java.io.File;
 class ClassLoaderHelper {
 
     private ClassLoaderHelper() {}
+
+    /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return true;
+    }
 
     /**
      * Returns an alternate path name for the given file

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8275703
+ * @library /test/lib
+ * @requires os.family == "mac"
+ * @run main/native/othervm -Djava.library.path=/usr/lib LibraryFromCache blas
+ * @run main/native/othervm -Djava.library.path=/usr/lib LibraryFromCache BLAS
+ * @summary Test System::loadLibrary to be able to load a library even
+ *          if it's not present on the filesystem on macOS which supports
+ *          dynamic library cache
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class LibraryFromCache {
+    public static void main(String[] args) throws IOException {
+        String libname = args[0];
+        if (!systemHasLibrary(libname)) {
+            System.out.println("Test skipped. Library " + libname + " not found");
+            return;
+        }
+
+        System.loadLibrary(libname);
+    }
+
+    /*
+     * Returns true if dlopen successfully loads the specified library
+     */
+    private static boolean systemHasLibrary(String libname) throws IOException {
+        Path launcher = Paths.get(System.getProperty("test.nativepath"), "LibraryCache");
+        ProcessBuilder pb = new ProcessBuilder(launcher.toString(), "lib" + libname + ".dylib");
+        OutputAnalyzer outputAnalyzer = new OutputAnalyzer(pb.start());
+        System.out.println(outputAnalyzer.getOutput());
+        return outputAnalyzer.getExitValue() == 0;
+    }
+}

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/exeLibraryCache.c
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/exeLibraryCache.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+int main(int argc, char** argv)
+{
+    void *handle;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <lib_filename_or_full_path>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    printf("Attempting to load library '%s'...\n", argv[1]);
+
+    handle = dlopen(argv[1], RTLD_LAZY);
+
+    if (handle == NULL) {
+       fprintf(stderr, "Unable to load library!\n");
+       return EXIT_FAILURE;
+    }
+
+    printf("Library successfully loaded!\n");
+
+    return dlclose(handle);
+}


### PR DESCRIPTION
Backport of JDK-8275703: System.loadLibrary fails on Big Sur for libraries hidden from filesystem

Manually resolved the merge conflict of the following file:

- src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275703](https://bugs.openjdk.java.net/browse/JDK-8275703): System.loadLibrary fails on Big Sur for libraries hidden from filesystem


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/282/head:pull/282` \
`$ git checkout pull/282`

Update a local copy of the PR: \
`$ git checkout pull/282` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 282`

View PR using the GUI difftool: \
`$ git pr show -t 282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/282.diff">https://git.openjdk.java.net/jdk17u/pull/282.diff</a>

</details>
