### PR TITLE
8272854: split runtime/CommandLine/PrintTouchedMethods.java test

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
@@ -28,8 +28,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @library /test/lib
- * @compile TestLogTouchedMethods.java PrintTouchedMethods.java
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+LogTouchedMethods PrintTouchedMethods
+ * @run driver PrintTouchedMethods
  */
 
 import java.io.File;
@@ -45,7 +44,7 @@ public class PrintTouchedMethods {
           "-XX:-UnlockDiagnosticVMOptions",
           "-XX:+LogTouchedMethods",
           "-XX:+PrintTouchedMethodsAtExit",
-          "TestLogTouchedMethods");
+          TestLogTouchedMethods.class.getName());
 
       // UnlockDiagnostic turned off, should fail
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -56,7 +55,7 @@ public class PrintTouchedMethods {
           "-XX:+UnlockDiagnosticVMOptions",
           "-XX:+LogTouchedMethods",
           "-XX:+PrintTouchedMethodsAtExit",
-          "TestLogTouchedMethods");
+          TestLogTouchedMethods.class.getName());
       output = new OutputAnalyzer(pb.start());
       // check order:
       // 1 "# Method::print_touched_methods version 1" is the first in first line
@@ -83,7 +82,7 @@ public class PrintTouchedMethods {
           "-Xint",
           "-XX:+LogTouchedMethods",
           "-XX:+PrintTouchedMethodsAtExit",
-          "TestLogTouchedMethods");
+          TestLogTouchedMethods.class.getName());
       output = new OutputAnalyzer(pb.start());
       lines = output.asLines();
 
@@ -106,7 +105,7 @@ public class PrintTouchedMethods {
           "-XX:+LogTouchedMethods",
           "-XX:+PrintTouchedMethodsAtExit",
           "-XX:-TieredCompilation",
-          "TestLogTouchedMethods");
+          TestLogTouchedMethods.class.getName());
       output = new OutputAnalyzer(pb.start());
       lines = output.asLines();
 
@@ -122,16 +121,5 @@ public class PrintTouchedMethods {
       output.shouldContain("TestLogTouchedMethods.methodA:()V");
       output.shouldNotContain("TestLogTouchedMethods.methodB:()V");
       output.shouldHaveExitValue(0);
-
-      // Test jcmd PrintTouchedMethods VM.print_touched_methods
-      String pid = Long.toString(ProcessTools.getProcessId());
-      pb = new ProcessBuilder();
-      pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.print_touched_methods"});
-      output = new OutputAnalyzer(pb.start());
-      try {
-        output.shouldContain("PrintTouchedMethods.main:([Ljava/lang/String;)V");
-      } catch (RuntimeException e) {
-        output.shouldContain("Unknown diagnostic command");
-      }
-  }
+    }
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethodsJcmd.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethodsJcmd.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8025692
+ * @summary Test jcmd PrintTouchedMethods VM.print_touched_methods
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @library /test/lib
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+LogTouchedMethods PrintTouchedMethodsJcmd
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.JDKToolFinder;
+
+public class PrintTouchedMethodsJcmd {
+
+    public static void main(String args[]) throws Exception {
+      var pid = Long.toString(ProcessHandle.current().pid());
+      var pb = new ProcessBuilder();
+      pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.print_touched_methods"});
+      var output = new OutputAnalyzer(pb.start());
+      try {
+        output.shouldContain("PrintTouchedMethodsJcmd.main:([Ljava/lang/String;)V");
+      } catch (RuntimeException e) {
+        output.shouldContain("Unknown diagnostic command");
+      }
+  }
+}


### PR DESCRIPTION
Clean backport to improve 17u testing.

Additional testing:
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272854](https://bugs.openjdk.java.net/browse/JDK-8272854): split runtime/CommandLine/PrintTouchedMethods.java test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/283/head:pull/283` \
`$ git checkout pull/283`

Update a local copy of the PR: \
`$ git checkout pull/283` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 283`

View PR using the GUI difftool: \
`$ git pr show -t 283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/283.diff">https://git.openjdk.java.net/jdk17u/pull/283.diff</a>

</details>
