### PR TITLE
8276805: java/awt/print/PrinterJob/CheckPrivilege.java fails due to disabled SecurityManager

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/CheckPrivilege.java
+++ b/test/jdk/java/awt/print/PrinterJob/CheckPrivilege.java
@@ -27,6 +27,7 @@
  * @bug 4151151
  * @summary Confirm that low-level print code does doPrivilege.
  * @author Graham Hamilton
+ * @run main/othervm -Djava.security.manager=allow CheckPrivilege
  */
 
 import java.awt.print.*;


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276805](https://bugs.openjdk.java.net/browse/JDK-8276805): java/awt/print/PrinterJob/CheckPrivilege.java fails due to disabled SecurityManager


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/284/head:pull/284` \
`$ git checkout pull/284`

Update a local copy of the PR: \
`$ git checkout pull/284` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 284`

View PR using the GUI difftool: \
`$ git pr show -t 284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/284.diff">https://git.openjdk.java.net/jdk17u/pull/284.diff</a>

</details>
