### PR TITLE
8275426: PretouchTask num_chunks calculation can overflow

### DIFF
--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -82,7 +82,7 @@ void PretouchTask::pretouch(const char* task_name, char* start_address, char* en
   }
 
   if (pretouch_gang != NULL) {
-    size_t num_chunks = (total_bytes + chunk_size - 1) / chunk_size;
+    size_t num_chunks = ((total_bytes - 1) / chunk_size) + 1;
 
     uint num_workers = (uint)MIN2(num_chunks, (size_t)pretouch_gang->total_workers());
     log_debug(gc, heap)("Running %s with %u workers for " SIZE_FORMAT " work units pre-touching " SIZE_FORMAT "B.",


### PR DESCRIPTION
Unclean backport to fix the overflow in pretouch code. There is a reproducer for x86_32.

The backport does not apply cleanly, because `pretouch_gang` was renamed to `pretouch_workers` later.
@kimbarrett, please ack this version.

Additional testing:
 - [x] Linux x86_32 reproducer
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_32 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275426](https://bugs.openjdk.java.net/browse/JDK-8275426): PretouchTask num_chunks calculation can overflow


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/286/head:pull/286` \
`$ git checkout pull/286`

Update a local copy of the PR: \
`$ git checkout pull/286` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 286`

View PR using the GUI difftool: \
`$ git pr show -t 286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/286.diff">https://git.openjdk.java.net/jdk17u/pull/286.diff</a>

</details>
