### PR TITLE
8273162: AbstractSplittableWithBrineGenerator does not create a random salt

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -2380,7 +2380,7 @@ public class RandomSupport {
             long bits = nextLong();
             long multiplier = (1L << SALT_SHIFT) - 1;
             long salt = multiplier << (64 - SALT_SHIFT);
-            while ((salt & multiplier) != 0) {
+            while ((salt & multiplier) == 0) {
                 long digit = Math.multiplyHigh(bits, multiplier);
                 salt = (salt >>> SALT_SHIFT) | (digit << (64 - SALT_SHIFT));
                 bits *= multiplier;


### PR DESCRIPTION
Clean backport.

Additional testing:
 - [x] `java/util/Random` tests
 - [x] `tier1`
 - [x] `tier2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273162](https://bugs.openjdk.java.net/browse/JDK-8273162): AbstractSplittableWithBrineGenerator does not create a random salt


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/288/head:pull/288` \
`$ git checkout pull/288`

Update a local copy of the PR: \
`$ git checkout pull/288` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 288`

View PR using the GUI difftool: \
`$ git pr show -t 288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/288.diff">https://git.openjdk.java.net/jdk17u/pull/288.diff</a>

</details>
