### PR TITLE
8272095: ProblemList java/nio/channels/FileChannel/Transfer2GPlus.java on linux-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -620,6 +620,8 @@ java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc6
 
 java/nio/channels/Selector/Wakeup.java                          6963118 windows-all
 
+java/nio/channels/FileChannel/Transfer2GPlus.java               8272047 linux-aarch64
+
 ############################################################################
 
 # jdk_rmi


### PR DESCRIPTION
Clean backport of a ProblemList.txt change. It is intended as a prerequisite to [JDK-8272047](https://bugs.openjdk.java.net/browse/JDK-8272047) fix to allow it to be applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272095](https://bugs.openjdk.java.net/browse/JDK-8272095): ProblemList java/nio/channels/FileChannel/Transfer2GPlus.java on linux-aarch64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/291/head:pull/291` \
`$ git checkout pull/291`

Update a local copy of the PR: \
`$ git checkout pull/291` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 291`

View PR using the GUI difftool: \
`$ git pr show -t 291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/291.diff">https://git.openjdk.java.net/jdk17u/pull/291.diff</a>

</details>
