### PR TITLE
8140241: (fc) Data transfer from FileChannel to itself causes hang in case of overlap

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileDispatcher.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,8 @@ abstract class FileDispatcher extends NativeDispatcher {
     abstract boolean canTransferToDirectly(SelectableChannel sc);
 
     abstract boolean transferToDirectlyNeedsPositionLock();
+
+    abstract boolean canTransferToFromOverlappedMap();
 
     abstract int setDirectIO(FileDescriptor fd, String path);
 }

--- a/src/java.base/unix/classes/sun/nio/ch/FileDispatcherImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/FileDispatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,6 +126,10 @@ class FileDispatcherImpl extends FileDispatcher {
         return false;
     }
 
+    boolean canTransferToFromOverlappedMap() {
+        return canTransferToFromOverlappedMap0();
+    }
+
     int setDirectIO(FileDescriptor fd, String path) {
         int result = -1;
         try {
@@ -183,6 +187,8 @@ class FileDispatcherImpl extends FileDispatcher {
     static native void dup0(FileDescriptor fd1, FileDescriptor fd2) throws IOException;
 
     static native void closeIntFD(int fd) throws IOException;
+
+    static native boolean canTransferToFromOverlappedMap0();
 
     static native int setDirect0(FileDescriptor fd) throws IOException;
 

--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -338,6 +338,16 @@ Java_sun_nio_ch_FileDispatcherImpl_closeIntFD(JNIEnv *env, jclass clazz, jint fd
     closeFileDescriptor(env, fd);
 }
 
+JNIEXPORT jboolean JNICALL
+Java_sun_nio_ch_FileDispatcherImpl_canTransferToFromOverlappedMap0(JNIEnv *env, jclass clazz)
+{
+#ifdef MACOSX
+    return JNI_FALSE;
+#else
+    return JNI_TRUE;
+#endif
+}
+
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_setDirect0(JNIEnv *env, jclass clazz,
                                            jobject fdo)

--- a/src/java.base/windows/classes/sun/nio/ch/FileDispatcherImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/FileDispatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,6 +122,10 @@ class FileDispatcherImpl extends FileDispatcher {
     }
 
     boolean transferToDirectlyNeedsPositionLock() {
+        return true;
+    }
+
+    boolean canTransferToFromOverlappedMap() {
         return true;
     }
 

--- a/test/jdk/java/nio/channels/FileChannel/TransferOverlappedFileChannel.java
+++ b/test/jdk/java/nio/channels/FileChannel/TransferOverlappedFileChannel.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8140241
+ * @summary Test transferring to and from same file channel
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.Random;
+
+public class TransferOverlappedFileChannel {
+
+    public static void main(String[] args) throws Exception {
+        File file = File.createTempFile("readingin", null);
+        file.deleteOnExit();
+        generateBigFile(file);
+        RandomAccessFile raf = new RandomAccessFile(file, "rw");
+        try (FileChannel channel = raf.getChannel()) {
+            transferToNoOverlap(file, channel);
+            transferToOverlap(file, channel);
+            transferFromNoOverlap(file, channel);
+            transferFromOverlap(file, channel);
+        } finally {
+            file.delete();
+        }
+    }
+
+    private static void transferToNoOverlap(File file, FileChannel channel)
+        throws IOException {
+        final long length = file.length();
+
+        // position at three quarters
+        channel.position(length*3/4);
+        // copy last quarter to third quarter
+        // (copied and overwritten regions do NOT overlap)
+        // So: 1 2 3 4 -> 1 2 4 4
+        channel.transferTo(length / 2, length / 4, channel);
+        System.out.println("transferToNoOverlap: OK");
+    }
+
+    private static void transferToOverlap(File file, FileChannel channel)
+        throws IOException {
+        final long length = file.length();
+
+        // position at half
+        channel.position(length/2);
+        // copy last half to second quarter
+        // (copied and overwritten regions DO overlap)
+        // So: 1 2 3 4 -> 1 3 4 4
+        channel.transferTo(length / 4, length / 2, channel);
+        System.out.println("transferToOverlap: OK");
+    }
+
+    private static void transferFromNoOverlap(File file, FileChannel channel)
+        throws IOException {
+        final long length = file.length();
+
+        // position at three quarters
+        channel.position(length*3/4);
+        // copy last quarter to third quarter
+        // (copied and overwritten regions do NOT overlap)
+        // So: 1 2 3 4 -> 1 2 4 4
+        channel.transferFrom(channel, length / 2, length / 4);
+        System.out.println("transferFromNoOverlap: OK");
+    }
+
+    private static void transferFromOverlap(File file, FileChannel channel)
+        throws IOException {
+        final long length = file.length();
+
+        // position at half
+        channel.position(length/2);
+        // copy last half to second quarter
+        // (copied and overwritten regions DO overlap)
+        // So: 1 2 3 4 -> 1 3 4 4
+        channel.transferFrom(channel, length / 4, length / 2);
+        System.out.println("transferFromOverlap: OK");
+    }
+
+    private static void generateBigFile(File file) throws Exception {
+        try (OutputStream out = new BufferedOutputStream(
+                new FileOutputStream(file))) {
+            byte[] randomBytes = new byte[1024];
+            Random rand = new Random(0);
+            rand.nextBytes(randomBytes);
+            for (int i = 0; i < 1024; i++) {
+                out.write(randomBytes);
+            }
+            out.flush();
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of a Mac-specific fix.

Additional testing:

 - [x] checked that added test passes on Mac with this patch. Was unable to reproduce the issue (in virtualized env) without the patch.
 - [x] ran jtreg:jdk/java/nio/channels/FileChannel/ on Mac, Linux and Windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8140241](https://bugs.openjdk.java.net/browse/JDK-8140241): (fc) Data transfer from FileChannel to itself causes hang in case of overlap


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/292/head:pull/292` \
`$ git checkout pull/292`

Update a local copy of the PR: \
`$ git checkout pull/292` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 292`

View PR using the GUI difftool: \
`$ git pr show -t 292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/292.diff">https://git.openjdk.java.net/jdk17u/pull/292.diff</a>

</details>
