### PR TITLE
8273351: bad tag in jdk.random module-info.java

### DIFF
--- a/src/jdk.random/share/classes/module-info.java
+++ b/src/jdk.random/share/classes/module-info.java
@@ -40,8 +40,7 @@ import jdk.internal.util.random.RandomSupport;
  * @provides jdk.random.Xoroshiro128PlusPlus
  * @provides jdk.random.Xoshiro256PlusPlus
  *
- * @use java.util.random.RandomGenerator
- * @use jdk.internal.util.random.RandomSupport
+ * @uses java.util.random.RandomGenerator
  *
  * @moduleGraph
  * @since 16


### PR DESCRIPTION
Clean backport to match JDK 18.

Additional testing:
 - [x] Linux x86_64 fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273351](https://bugs.openjdk.java.net/browse/JDK-8273351): bad tag in jdk.random module-info.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/295/head:pull/295` \
`$ git checkout pull/295`

Update a local copy of the PR: \
`$ git checkout pull/295` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 295`

View PR using the GUI difftool: \
`$ git pr show -t 295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/295.diff">https://git.openjdk.java.net/jdk17u/pull/295.diff</a>

</details>
