### PR TITLE
8275811: Incorrect instance to dispose

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/InputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/InputRecord.java
@@ -122,7 +122,7 @@ abstract class InputRecord implements Record, Closeable {
          * Since MAC's doFinal() is called for every SSL/TLS packet, it's
          * not necessary to do the same with MAC's.
          */
-        readCipher.dispose();
+        this.readCipher.dispose();
 
         this.readCipher = readCipher;
     }

--- a/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
@@ -141,6 +141,11 @@ abstract class OutputRecord
     // SSLEngine and SSLSocket
     abstract void encodeChangeCipherSpec() throws IOException;
 
+    // SSLEngine and SSLSocket
+    void disposeWriteCipher() {
+        throw new UnsupportedOperationException();
+    }
+
     // apply to SSLEngine only
     Ciphertext encode(
         ByteBuffer[] srcs, int srcsOffset, int srcsLength,
@@ -190,7 +195,7 @@ abstract class OutputRecord
              * Since MAC's doFinal() is called for every SSL/TLS packet, it's
              * not necessary to do the same with MAC's.
              */
-            writeCipher.dispose();
+            disposeWriteCipher();
 
             this.writeCipher = writeCipher;
             this.isFirstAppOutputRecord = true;
@@ -219,7 +224,7 @@ abstract class OutputRecord
             flush();
 
             // Dispose of any intermediate state in the underlying cipher.
-            writeCipher.dispose();
+            disposeWriteCipher();
 
             this.writeCipher = writeCipher;
             this.isFirstAppOutputRecord = true;

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
@@ -244,6 +244,11 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
     }
 
     @Override
+    void disposeWriteCipher() {
+        writeCipher.dispose();
+    }
+
+    @Override
     public void flush() throws IOException {
         recordLock.lock();
         try {


### PR DESCRIPTION
Clean port of JDK-8275811

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275811](https://bugs.openjdk.java.net/browse/JDK-8275811): Incorrect instance to dispose


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/297/head:pull/297` \
`$ git checkout pull/297`

Update a local copy of the PR: \
`$ git checkout pull/297` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 297`

View PR using the GUI difftool: \
`$ git pr show -t 297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/297.diff">https://git.openjdk.java.net/jdk17u/pull/297.diff</a>

</details>
