### PR TITLE
8264293: Create implementation for NSAccessibilityMenu protocol peer

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -1518,54 +1518,6 @@ JNI_COCOA_EXIT(env);
 
 /*
  * Class:     sun_lwawt_macosx_CAccessible
- * Method:    menuOpened
- * Signature: (I)V
- */
-JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuOpened
-(JNIEnv *env, jclass jklass, jlong element)
-{
-JNI_COCOA_ENTER(env);
-    [ThreadUtilities performOnMainThread:@selector(postMenuOpened)
-                     on:(JavaComponentAccessibility *)jlong_to_ptr(element)
-                     withObject:nil
-                     waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
-}
-
-/*
- * Class:     sun_lwawt_macosx_CAccessible
- * Method:    menuClosed
- * Signature: (I)V
- */
-JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuClosed
-(JNIEnv *env, jclass jklass, jlong element)
-{
-JNI_COCOA_ENTER(env);
-    [ThreadUtilities performOnMainThread:@selector(postMenuClosed)
-                     on:(JavaComponentAccessibility *)jlong_to_ptr(element)
-                     withObject:nil
-                     waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
-}
-
-/*
- * Class:     sun_lwawt_macosx_CAccessible
- * Method:    menuItemSelected
- * Signature: (I)V
- */
-JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuItemSelected
-(JNIEnv *env, jclass jklass, jlong element)
-{
-JNI_COCOA_ENTER(env);
-    [ThreadUtilities performOnMainThread:@selector(postMenuItemSelected)
-                     on:(JavaComponentAccessibility *)jlong_to_ptr(element)
-                     withObject:nil
-                     waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
-}
-
-/*
- * Class:     sun_lwawt_macosx_CAccessible
  * Method:    unregisterFromCocoaAXSystem
  * Signature: (I)V
  */

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -122,7 +122,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:46];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:50];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -152,6 +152,10 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"ListAccessibility" forKey:@"list"];
     [rolesMap setObject:@"OutlineAccessibility" forKey:@"tree"];
     [rolesMap setObject:@"TableAccessibility" forKey:@"table"];
+    [rolesMap setObject:@"MenuBarAccessibility" forKey:@"menubar"];
+    [rolesMap setObject:@"MenuAccessibility" forKey:@"menu"];
+    [rolesMap setObject:@"MenuItemAccessibility" forKey:@"menuitem"];
+    [rolesMap setObject:@"MenuAccessibility" forKey:@"popupmenu"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,
@@ -1247,6 +1251,54 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_selectedCellsChanged
 {
     JNI_COCOA_ENTER(env);
         [ThreadUtilities performOnMainThread:@selector(postSelectedCellsChanged)
+                         on:(CommonComponentAccessibility *)jlong_to_ptr(element)
+                         withObject:nil
+                         waitUntilDone:NO];
+    JNI_COCOA_EXIT(env);
+}
+
+/*
+ * Class:     sun_lwawt_macosx_CAccessible
+ * Method:    menuOpened
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuOpened
+    (JNIEnv *env, jclass jklass, jlong element)
+{
+    JNI_COCOA_ENTER(env);
+        [ThreadUtilities performOnMainThread:@selector(postMenuOpened)
+                         on:(CommonComponentAccessibility *)jlong_to_ptr(element)
+                         withObject:nil
+                         waitUntilDone:NO];
+    JNI_COCOA_EXIT(env);
+}
+
+/*
+ * Class:     sun_lwawt_macosx_CAccessible
+ * Method:    menuClosed
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuClosed
+    (JNIEnv *env, jclass jklass, jlong element)
+{
+    JNI_COCOA_ENTER(env);
+        [ThreadUtilities performOnMainThread:@selector(postMenuClosed)
+                         on:(CommonComponentAccessibility *)jlong_to_ptr(element)
+                         withObject:nil
+                         waitUntilDone:NO];
+    JNI_COCOA_EXIT(env);
+}
+
+/*
+ * Class:     sun_lwawt_macosx_CAccessible
+ * Method:    menuItemSelected
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuItemSelected
+    (JNIEnv *env, jclass jklass, jlong element)
+{
+    JNI_COCOA_ENTER(env);
+        [ThreadUtilities performOnMainThread:@selector(postMenuItemSelected)
                          on:(CommonComponentAccessibility *)jlong_to_ptr(element)
                          withObject:nil
                          waitUntilDone:NO];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "CommonComponentAccessibility.h"
+#import "GroupAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface MenuAccessibility : GroupAccessibility {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "MenuAccessibility.h"
+
+/*
+ * Implementing a protocol that represents menus both as submenu and as a
+ * MenuBar components
+ */
+@implementation MenuAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+        return [[[self parent] javaRole] isEqualToString:@"combobox"]
+               ? NSAccessibilityPopUpButtonRole
+               : NSAccessibilityMenuRole;
+}
+
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuBarAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuBarAccessibility.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "CommonComponentAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface MenuBarAccessibility : CommonComponentAccessibility {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuBarAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuBarAccessibility.m
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "MenuBarAccessibility.h"
+#import "JNIUtilities.h"
+#import "ThreadUtilities.h"
+#import "sun_lwawt_macosx_CAccessibility.h"
+
+/*
+ * This is the protocol for the Menu Bar component
+ */
+@implementation MenuBarAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityMenuBarRole;
+}
+
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuItemAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuItemAccessibility.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "CommonComponentAccessibility.h"
+#import "ButtonAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface MenuItemAccessibility : ButtonAccessibility {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (void)handleAction:(NSMenuItem * _Nonnull)sender;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuItemAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuItemAccessibility.m
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "MenuItemAccessibility.h"
+
+/*
+ * This is the protocol for the MenuItem component.
+ */
+@implementation MenuItemAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityMenuItemRole;
+}
+
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
+- (BOOL)accessibilityPerformPick
+{
+    return [self performAccessibleAction:0];
+}
+
+- (BOOL)accessibilityPerformPress
+{
+    return [self performAccessibleAction:0];
+}
+
+- (NSString * _Nullable)accessibilityLabel
+{
+    return [super accessibilityLabel];
+}
+
+- (id _Nullable)accessibilityValue
+{
+    return [super accessibilityValue];
+}
+
+@end


### PR DESCRIPTION
Backport of JDK-8264293. Changes applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8264293](https://bugs.openjdk.java.net/browse/JDK-8264293): Create implementation for NSAccessibilityMenu protocol peer
 * [JDK-8264296](https://bugs.openjdk.java.net/browse/JDK-8264296): Create implementation for NSAccessibilityPopUpButton protocol peer
 * [JDK-8264295](https://bugs.openjdk.java.net/browse/JDK-8264295): Create implementation for NSAccessibilityMenuItem protocol peer
 * [JDK-8264294](https://bugs.openjdk.java.net/browse/JDK-8264294): Create implementation for NSAccessibilityMenuBar protocol peer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/298/head:pull/298` \
`$ git checkout pull/298`

Update a local copy of the PR: \
`$ git checkout pull/298` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 298`

View PR using the GUI difftool: \
`$ git pr show -t 298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/298.diff">https://git.openjdk.java.net/jdk17u/pull/298.diff</a>

</details>
