### PR TITLE
8272047: java/nio/channels/FileChannel/Transfer2GPlus.java failed with Unexpected transfer size: 2147418112

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -620,8 +620,6 @@ java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc6
 
 java/nio/channels/Selector/Wakeup.java                          6963118 windows-all
 
-java/nio/channels/FileChannel/Transfer2GPlus.java               8272047 linux-aarch64
-
 ############################################################################
 
 # jdk_rmi


### PR DESCRIPTION
Clean backport of the Linux-aarch64 fix.

Additional testing:

 - [x] checked that fixed tests passes on aarch64 Linux; was unable to reproduce the problem without the fix (got limited access to aarch64 machine with 4kb page size)
 - [x] ran jtreg:jdk/java/nio/channels/FileChannel/ on Linux (aarch64 and x86_64), Windows and Mac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272047](https://bugs.openjdk.java.net/browse/JDK-8272047): java/nio/channels/FileChannel/Transfer2GPlus.java failed with Unexpected transfer size: 2147418112


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/302/head:pull/302` \
`$ git checkout pull/302`

Update a local copy of the PR: \
`$ git checkout pull/302` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 302`

View PR using the GUI difftool: \
`$ git pr show -t 302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/302.diff">https://git.openjdk.java.net/jdk17u/pull/302.diff</a>

</details>
