### PR TITLE
8277212: GC accidentally cleans valid megamorphic vtable inline caches

### DIFF
--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -478,6 +478,10 @@ bool CompiledMethod::clean_ic_if_metadata_is_dead(CompiledIC *ic) {
       } else {
         ShouldNotReachHere();
       }
+    } else {
+      // This inline cache is a megamorphic vtable call. Those ICs never hold
+      // any Metadata and should therefore never be cleaned by this function.
+      return true;
     }
   }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit openjdk/jdk@976c2bb.

The commit being backported was authored by Stefan Karlsson on 19 Nov 2021 and was reviewed by Erik Österlund, Per Liden, Coleen Phillimore and Tobias Hartmann.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277212](https://bugs.openjdk.java.net/browse/JDK-8277212): GC accidentally cleans valid megamorphic vtable inline caches


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/303/head:pull/303` \
`$ git checkout pull/303`

Update a local copy of the PR: \
`$ git checkout pull/303` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 303`

View PR using the GUI difftool: \
`$ git pr show -t 303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/303.diff">https://git.openjdk.java.net/jdk17u/pull/303.diff</a>

</details>
