### PR TITLE
8264297: Create implementation for NSAccessibilityProgressIndicator protocol peer

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -122,7 +122,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:50];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:51];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -156,6 +156,7 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"MenuAccessibility" forKey:@"menu"];
     [rolesMap setObject:@"MenuItemAccessibility" forKey:@"menuitem"];
     [rolesMap setObject:@"MenuAccessibility" forKey:@"popupmenu"];
+    [rolesMap setObject:@"ProgressIndicatorAccessibility" forKey:@"progressbar"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ProgressIndicatorAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ProgressIndicatorAccessibility.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "GroupAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface ProgressIndicatorAccessibility : GroupAccessibility {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityValue;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ProgressIndicatorAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ProgressIndicatorAccessibility.m
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "ProgressIndicatorAccessibility.h"
+
+/*
+ * Implementation of the accessibility peer for the NSProgressIndicator role.
+ * Main usage is JProgressBar
+ */
+@implementation ProgressIndicatorAccessibility
+
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityProgressIndicatorRole;
+}
+
+- (NSString * _Nullable)accessibilityValue
+{
+    return [super accessibilityValue];
+}
+
+@end


### PR DESCRIPTION
Backport of JDK-8264297, fix applied without issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264297](https://bugs.openjdk.java.net/browse/JDK-8264297): Create implementation for NSAccessibilityProgressIndicator protocol peer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/305/head:pull/305` \
`$ git checkout pull/305`

Update a local copy of the PR: \
`$ git checkout pull/305` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 305`

View PR using the GUI difftool: \
`$ git pr show -t 305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/305.diff">https://git.openjdk.java.net/jdk17u/pull/305.diff</a>

</details>
