### PR TITLE
8272859: Javadoc external links should only have feature version number in URL

### DIFF
--- a/make/conf/javadoc.conf
+++ b/make/conf/javadoc.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 #
 
 # URLs
-JAVADOC_BASE_URL=https://docs.oracle.com/pls/topic/lookup?ctx=javase$(VERSION_NUMBER)&amp;id=homepage
+JAVADOC_BASE_URL=https://docs.oracle.com/pls/topic/lookup?ctx=javase$(VERSION_FEATURE)&amp;id=homepage
 BUG_SUBMIT_URL=https://bugreport.java.com/bugreport/
 COPYRIGHT_URL=legal/copyright.html
-LICENSE_URL=https://www.oracle.com/java/javase/terms/license/java$(VERSION_NUMBER)speclicense.html
+LICENSE_URL=https://www.oracle.com/java/javase/terms/license/java$(VERSION_FEATURE)speclicense.html
 REDISTRIBUTION_URL=https://www.oracle.com/technetwork/java/redist-137594.html
 OTHER_JDK_VERSIONS_URL=https://docs.oracle.com/en/java/javase/index.html


### PR DESCRIPTION
Clean backport of JDK-8272859

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272859](https://bugs.openjdk.java.net/browse/JDK-8272859): Javadoc external links should only have feature version number in URL


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/306/head:pull/306` \
`$ git checkout pull/306`

Update a local copy of the PR: \
`$ git checkout pull/306` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 306`

View PR using the GUI difftool: \
`$ git pr show -t 306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/306.diff">https://git.openjdk.java.net/jdk17u/pull/306.diff</a>

</details>
