### PR TITLE
8271323: [TESTBUG] serviceability/sa/ClhsdbCDSCore.java fails with -XX:TieredStopAtLevel=1

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -125,8 +125,8 @@ public class ClhsdbCDSCore {
 
             List testJavaOpts = Arrays.asList(Utils.getTestJavaOpts());
 
-            if (testJavaOpts.contains("-Xcomp") && testJavaOpts.contains("-XX:TieredStopAtLevel=1")) {
-                // No MDOs are allocated in -XX:TieredStopAtLevel=1 + -Xcomp mode
+            if (testJavaOpts.contains("-XX:TieredStopAtLevel=1")) {
+                // No MDOs are allocated in -XX:TieredStopAtLevel=1
                 // The reason is methods being compiled aren't hot enough
                 // Let's not call printmdo in such scenario
                 cmds = List.of("printall", "jstack -v");


### PR DESCRIPTION
…X:TieredStopAtLevel=1

Reviewed-by: cjplummer, kvn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271323](https://bugs.openjdk.java.net/browse/JDK-8271323): [TESTBUG] serviceability/sa/ClhsdbCDSCore.java fails with -XX:TieredStopAtLevel=1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/308/head:pull/308` \
`$ git checkout pull/308`

Update a local copy of the PR: \
`$ git checkout pull/308` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 308`

View PR using the GUI difftool: \
`$ git pr show -t 308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/308.diff">https://git.openjdk.java.net/jdk17u/pull/308.diff</a>

</details>
