### PR TITLE
8275863: Use encodeASCII for ASCII-compatible DoubleByte encodings

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -151,6 +151,7 @@ module java.base {
         java.management,
         java.naming,
         java.rmi,
+        jdk.charsets,
         jdk.jartool,
         jdk.jlink,
         jdk.net,

--- a/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
+++ b/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
@@ -111,11 +111,11 @@ public class DoubleByte {
         Arrays.fill(B2C_UNMAPPABLE, UNMAPPABLE_DECODING);
     }
 
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
     public static class Decoder extends CharsetDecoder
                                 implements DelegatableDecoder, ArrayDecoder
     {
-        private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
-
         final char[][] b2c;
         final char[] b2cSB;
         final int b2Min;
@@ -601,6 +601,11 @@ public class DoubleByte {
             int dl = dst.arrayOffset() + dst.limit();
 
             try {
+                if (isASCIICompatible) {
+                    int n = JLA.encodeASCII(sa, sp, da, dp, Math.min(dl - dp, sl - sp));
+                    sp += n;
+                    dp += n;
+                }
                 while (sp < sl) {
                     char c = sa[sp];
                     int bb = encodeChar(c);
@@ -681,7 +686,11 @@ public class DoubleByte {
         public int encode(char[] src, int sp, int len, byte[] dst) {
             int dp = 0;
             int sl = sp + len;
-            int dl = dst.length;
+            if (isASCIICompatible) {
+                int n = JLA.encodeASCII(src, sp, dst, dp, len);
+                sp += n;
+                dp += n;
+            }
             while (sp < sl) {
                 char c = src[sp++];
                 int bb = encodeChar(c);

--- a/src/java.base/share/classes/sun/nio/cs/HKSCS.java
+++ b/src/java.base/share/classes/sun/nio/cs/HKSCS.java
@@ -42,9 +42,9 @@ public class HKSCS {
         static int b2Min = 0x40;
         static int b2Max = 0xfe;
 
-        private char[][] b2cBmp;
-        private char[][] b2cSupp;
-        private DoubleByte.Decoder big5Dec;
+        private final char[][] b2cBmp;
+        private final char[][] b2cSupp;
+        private final DoubleByte.Decoder big5Dec;
 
         protected Decoder(Charset cs,
                           DoubleByte.Decoder big5Dec,
@@ -94,7 +94,6 @@ public class HKSCS {
                     int b1 = sa[sp] & 0xff;
                     char c = decodeSingle(b1);
                     int inSize = 1, outSize = 1;
-                    char[] cc = null;
                     if (c == UNMAPPABLE_DECODING) {
                         if (sl - sp < 2)
                             return CoderResult.UNDERFLOW;
@@ -137,7 +136,6 @@ public class HKSCS {
             int mark = src.position();
             try {
                 while (src.hasRemaining()) {
-                    char[] cc = null;
                     int b1 = src.get() & 0xff;
                     int inSize = 1, outSize = 1;
                     char c = decodeSingle(b1);
@@ -230,9 +228,9 @@ public class HKSCS {
     }
 
     public static class Encoder extends DoubleByte.Encoder {
-        private DoubleByte.Encoder big5Enc;
-        private char[][] c2bBmp;
-        private char[][] c2bSupp;
+        private final DoubleByte.Encoder big5Enc;
+        private final char[][] c2bBmp;
+        private final char[][] c2bSupp;
 
         protected Encoder(Charset cs,
                           DoubleByte.Encoder big5Enc,

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -112,6 +112,8 @@ grant codeBase "jrt:/jdk.charsets" {
     permission java.util.PropertyPermission "os.name", "read";
     permission java.lang.RuntimePermission "charsetProvider";
     permission java.lang.RuntimePermission
+                   "accessClassInPackage.jdk.internal.access";
+    permission java.lang.RuntimePermission
                    "accessClassInPackage.jdk.internal.misc";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.cs";
 };

--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/EUC_JP.java.template
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/EUC_JP.java.template
@@ -25,6 +25,9 @@
 
 package $PACKAGE$;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -43,6 +46,8 @@ public class EUC_JP
     extends Charset
     implements HistoricallyNamedCharset
 {
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
     public EUC_JP() {
         super("EUC-JP",  $ALIASES$);
     }
@@ -303,6 +308,11 @@ public class EUC_JP
             byte[]  tmpBuf = new byte[3];
 
             try {
+                if (enc0201.isASCIICompatible()) {
+                    int n = JLA.encodeASCII(sa, sp, da, dp, Math.min(dl - dp, sl - sp));
+                    sp += n;
+                    dp += n;
+                }
                 while (sp < sl) {
                     outputByte = tmpBuf;
                     char c = sa[sp];


### PR DESCRIPTION
Clean backport of JDK-8275863

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275863](https://bugs.openjdk.java.net/browse/JDK-8275863): Use encodeASCII for ASCII-compatible DoubleByte encodings


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/311/head:pull/311` \
`$ git checkout pull/311`

Update a local copy of the PR: \
`$ git checkout pull/311` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 311`

View PR using the GUI difftool: \
`$ git pr show -t 311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/311.diff">https://git.openjdk.java.net/jdk17u/pull/311.diff</a>

</details>
