### PR TITLE
8274265: Suspicious string concatenation in logTestUtils.inline.hpp

### DIFF
--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -32,7 +32,7 @@
 #define LOG_TEST_STRING_LITERAL "a (hopefully) unique log message for testing"
 
 static const char* invalid_selection_substr[] = {
-  "=", "+", " ", "+=", "+=*", "*+", " +", "**", "++", ".", ",", ",," ",+",
+  "=", "+", " ", "+=", "+=*", "*+", " +", "**", "++", ".", ",", ",,", ",+",
   " *", "all+", "all*", "+all", "+all=Warning", "==Info", "=InfoWarning",
   "BadTag+", "logging++", "logging*+", ",=", "gc+gc+"
 };

--- a/test/hotspot/gtest/logging/test_logFileOutput.cpp
+++ b/test/hotspot/gtest/logging/test_logFileOutput.cpp
@@ -74,7 +74,7 @@ TEST_VM(LogFileOutput, parse_invalid) {
     "filecount= 2", "filesize=2 ",
     "filecount=ab", "filesize=0xz",
     "filecount=1MB", "filesize=99bytes",
-    "filesize=9999999999999999999999999"
+    "filesize=9999999999999999999999999",
     "filecount=9999999999999999999999999"
   };
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit c57a6c62 from the openjdk/jdk repository.

The commit being backported was authored by Jesper Steen Møller on 28 Sep 2021 and was reviewed by Christoph Langer and Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274265](https://bugs.openjdk.java.net/browse/JDK-8274265): Suspicious string concatenation in logTestUtils.inline.hpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/312/head:pull/312` \
`$ git checkout pull/312`

Update a local copy of the PR: \
`$ git checkout pull/312` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 312`

View PR using the GUI difftool: \
`$ git pr show -t 312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/312.diff">https://git.openjdk.java.net/jdk17u/pull/312.diff</a>

</details>
