### PR TITLE
8277159: Fix java/nio/file/FileStore/Basic.java test by ignoring /run/user/* mount points

### DIFF
--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -145,6 +145,16 @@ public class Basic {
                     // reflect whether the space attributes would be accessible
                     // were access to be permitted
                     System.err.format("%s is inaccessible\n", store);
+                } catch (FileSystemException fse) {
+                    // On Linux, ignore the FSE if the path is one of the
+                    // /run/user/$UID mounts created by pam_systemd(8) as it
+                    // might be mounted as a fuse.portal filesystem and
+                    // its access attempt might fail with EPERM
+                    if (!Platform.isLinux() || store.toString().indexOf("/run/user") == -1) {
+                        throw new RuntimeException(fse);
+                    } else {
+                        System.err.format("%s error: %s\n", store, fse);
+                    }
                 }
 
                 // two distinct FileStores should not be equal


### PR DESCRIPTION
Clean backport of a test fix.

Additional testing:

- [x] checked that updated test passes on Fedora 34 with `/run/user/1000/doc` mount point present (created with `/usr/libexec/xdg-document-portal`)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277159](https://bugs.openjdk.java.net/browse/JDK-8277159): Fix java/nio/file/FileStore/Basic.java test by ignoring /run/user/* mount points


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/313/head:pull/313` \
`$ git checkout pull/313`

Update a local copy of the PR: \
`$ git checkout pull/313` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 313`

View PR using the GUI difftool: \
`$ git pr show -t 313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/313.diff">https://git.openjdk.java.net/jdk17u/pull/313.diff</a>

</details>
