### PR TITLE
8277165: jdeps --multi-release --print-module-deps fails if module-info.class in different versioned directories

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ClassFileReader.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ClassFileReader.java
@@ -356,7 +356,8 @@ public class ClassFileReader implements Closeable {
         protected ClassFile readClassFile(JarFile jarfile, JarEntry e) throws IOException {
             try (InputStream is = jarfile.getInputStream(e)) {
                 ClassFile cf = ClassFile.read(is);
-                if (jarfile.isMultiRelease()) {
+                // exclude module-info.class since this jarFile is on classpath
+                if (jarfile.isMultiRelease() && !cf.getName().equals("module-info")) {
                     VersionHelper.add(jarfile, e, cf);
                 }
                 return cf;
@@ -437,5 +438,4 @@ public class ClassFileReader implements Closeable {
             throw new UnsupportedOperationException("Not supported yet.");
         }
     }
-    private static final String MODULE_INFO = "module-info.class";
 }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/DependencyFinder.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/DependencyFinder.java
@@ -268,7 +268,14 @@ class DependencyFinder {
             }
             return targets;
         } catch (InterruptedException|ExecutionException e) {
-            throw new Error(e);
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException x) {
+                throw x;
+            } else if (cause instanceof Error x) {
+                throw x;
+            } else {
+                throw new Error(e);
+            }
         }
     }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/MultiReleaseException.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/MultiReleaseException.java
@@ -46,7 +46,7 @@ class MultiReleaseException extends RuntimeException {
      *        The detail message array
      */
     public MultiReleaseException(String key, Object... params) {
-        super();
+        super(JdepsTask.getMessage(key, params));
         this.key = key;
         this.params = params;
     }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/VersionHelper.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/VersionHelper.java
@@ -55,15 +55,10 @@ public class VersionHelper {
                 String version = realName.substring(len, n);
                 assert (Integer.parseInt(version) > 8);
                 String name = cf.getName().replace('/', '.');
-                if (nameToVersion.containsKey(name)) {
-                    if (!version.equals(nameToVersion.get(name))) {
-                        throw new MultiReleaseException(
-                                "err.multirelease.version.associated",
-                                name, nameToVersion.get(name), version
-                        );
-                    }
-                } else {
-                    nameToVersion.put(name, version);
+                String v = nameToVersion.computeIfAbsent(name, _n -> version);
+                if (!version.equals(v)) {
+                    throw new MultiReleaseException("err.multirelease.version.associated",
+                                name, nameToVersion.get(name), version);
                 }
             } else {
                 throw new MultiReleaseException("err.multirelease.jar.malformed",

--- a/test/langtools/tools/jdeps/multiVersion/MultiVersionError.java
+++ b/test/langtools/tools/jdeps/multiVersion/MultiVersionError.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277165
+ * @library ../lib
+ * @build CompilerUtils
+ * @run testng MultiVersionError
+ * @summary Tests multiple versions of the same class file
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.spi.ToolProvider;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+public class MultiVersionError {
+    private static final String TEST_SRC = System.getProperty("test.src");
+    private static final Path SRC_DIR = Paths.get(TEST_SRC, "src");
+
+    private static final Path MODS_DIR = Paths.get("mods");
+
+    private static final ToolProvider JAR_TOOL = ToolProvider.findFirst("jar").orElseThrow();
+    private static final Set<String> modules = Set.of("m1", "m2");
+
+    /**
+     * Compiles classes used by the test
+     */
+    @BeforeTest
+    public void compileAll() throws Exception {
+        CompilerUtils.cleanDir(MODS_DIR);
+        modules.forEach(mn ->
+                assertTrue(CompilerUtils.compileModule(SRC_DIR, MODS_DIR, mn)));
+
+        // create a modular multi-release m1.jar
+        Path m1 = MODS_DIR.resolve("m1");
+        Path m2 = MODS_DIR.resolve("m2");
+        jar("cf", "m1.jar", "-C", m1.toString(), "p/Test.class",
+                "--release", "9", "-C", m1.toString(), "module-info.class",
+                "--release", "11", "-C", m1.toString(), "p/internal/P.class");
+        jar("cf", "m2.jar", "-C", m2.toString(), "q/Q.class",
+                "--release", "10", "-C", m2.toString(), "module-info.class");
+
+        // package private p/internal/P.class in m1 instead
+        jar("cf", "m3.jar", "-C", m2.toString(), "q/Q.class",
+                "--release", "12", "-C", m2.toString(), "module-info.class",
+                "-C", m1.toString(), "p/internal/P.class");
+    }
+
+    /*
+     * multiple module-info.class from different versions should be excluded
+     * from multiple version check.
+     */
+    @Test
+    public void noMultiVersionClass() {
+        // skip parsing p.internal.P to workaround JDK-8277681
+        JdepsRunner jdepsRunner = new JdepsRunner("--print-module-deps", "--multi-release", "10",
+                                                  "--ignore-missing-deps",
+                                                  "--module-path", "m1.jar", "m2.jar");
+        int rc = jdepsRunner.run(true);
+        assertTrue(rc == 0);
+        assertTrue(jdepsRunner.outputContains("java.base,m1"));
+    }
+
+    /*
+     * Detect multiple versions of p.internal.P class
+     */
+    @Test
+    public void classInMultiVersions() {
+        JdepsRunner jdepsRunner = new JdepsRunner("--print-module-deps", "--multi-release", "13",
+                                                  "--module-path", "m1.jar", "m3.jar");
+        int rc = jdepsRunner.run(true);
+        assertTrue(rc != 0);
+        assertTrue(jdepsRunner.outputContains("class p.internal.P already associated with version"));
+    }
+
+    private static void jar(String... options) {
+        int rc = JAR_TOOL.run(System.out, System.err, options);
+        assertTrue(rc == 0);
+    }
+}

--- a/test/langtools/tools/jdeps/multiVersion/src/m1/module-info.java
+++ b/test/langtools/tools/jdeps/multiVersion/src/m1/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m1 {
+    requires java.management;
+    exports p;
+}

--- a/test/langtools/tools/jdeps/multiVersion/src/m1/p/Test.java
+++ b/test/langtools/tools/jdeps/multiVersion/src/m1/p/Test.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p;
+
+public class Test {
+}

--- a/test/langtools/tools/jdeps/multiVersion/src/m1/p/internal/P.java
+++ b/test/langtools/tools/jdeps/multiVersion/src/m1/p/internal/P.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p.internal;
+
+import java.lang.management.*;
+
+class P {
+     private static RuntimeMXBean mxbean = ManagementFactory.getRuntimeMXBean();
+}

--- a/test/langtools/tools/jdeps/multiVersion/src/m2/module-info.java
+++ b/test/langtools/tools/jdeps/multiVersion/src/m2/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m2 {
+    requires m1;
+    requires java.logging;
+}

--- a/test/langtools/tools/jdeps/multiVersion/src/m2/p/internal/P.java
+++ b/test/langtools/tools/jdeps/multiVersion/src/m2/p/internal/P.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p.internal;
+
+import java.util.logging.Logger;
+
+public class P {
+     private static final Logger LOGGER = Logger.getLogger("p");
+}

--- a/test/langtools/tools/jdeps/multiVersion/src/m2/q/Q.java
+++ b/test/langtools/tools/jdeps/multiVersion/src/m2/q/Q.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package q;
+
+public class Q {
+    static p.Test t = new p.Test();
+
+    public Q() {
+        Object o = new p.internal.P();
+    }
+}


### PR DESCRIPTION
This pull request contains a backport of commit 7e54d065 from the openjdk/jdk repository.

The commit being backported was authored by Mandy Chung on 26 Nov 2021 and was reviewed by Jorn Vernee and Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8277165](https://bugs.openjdk.java.net/browse/JDK-8277165): jdeps --multi-release --print-module-deps fails if module-info.class in different versioned directories
 * [JDK-8277166](https://bugs.openjdk.java.net/browse/JDK-8277166): Data race in jdeps VersionHelper
 * [JDK-8277123](https://bugs.openjdk.java.net/browse/JDK-8277123): jdeps does not report some exceptions correctly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/314/head:pull/314` \
`$ git checkout pull/314`

Update a local copy of the PR: \
`$ git checkout pull/314` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 314`

View PR using the GUI difftool: \
`$ git pr show -t 314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/314.diff">https://git.openjdk.java.net/jdk17u/pull/314.diff</a>

</details>
