### PR TITLE
8273704: DrawStringWithInfiniteXform.java failed : drawString with InfiniteXform transform takes long time

### DIFF
--- a/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
+++ b/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
@@ -35,11 +35,12 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 public class DrawStringWithInfiniteXform {
-    Timer timer;
-    boolean done;
+
+    volatile Timer timer;
+    volatile boolean done;
+
     class ScheduleTask extends TimerTask {
         public void run() {
-            timer.cancel();
             if (!done) {
                 throw new
                 RuntimeException("drawString with InfiniteXform transform takes long time");
@@ -48,7 +49,7 @@ public class DrawStringWithInfiniteXform {
     }
     public DrawStringWithInfiniteXform() {
         timer = new Timer();
-        timer.schedule(new ScheduleTask(), 10000);
+        timer.schedule(new ScheduleTask(), 20000);
     }
 
     public static void main(String [] args) {
@@ -73,6 +74,7 @@ public class DrawStringWithInfiniteXform {
             g2d.drawString("abc", 20, 20);
         }
         done = true;
+        timer.cancel();
         System.out.println("Test passed");
     }
 }


### PR DESCRIPTION
I would like to backport this because we see the error sporadic in the older releases, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273704](https://bugs.openjdk.java.net/browse/JDK-8273704): DrawStringWithInfiniteXform.java failed : drawString with InfiniteXform transform takes long time


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/315/head:pull/315` \
`$ git checkout pull/315`

Update a local copy of the PR: \
`$ git checkout pull/315` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 315`

View PR using the GUI difftool: \
`$ git pr show -t 315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/315.diff">https://git.openjdk.java.net/jdk17u/pull/315.diff</a>

</details>
