### PR TITLE
8277981: String Deduplication table is never cleaned up due to bad dead_factor_for_cleanup

### DIFF
--- a/src/hotspot/share/gc/shared/stringdedup/stringDedupConfig.cpp
+++ b/src/hotspot/share/gc/shared/stringdedup/stringDedupConfig.cpp
@@ -161,6 +161,6 @@ void StringDedup::Config::initialize() {
   _load_factor_for_shrink = StringDeduplicationShrinkTableLoad;
   _load_factor_target = StringDeduplicationTargetTableLoad;
   _minimum_dead_for_cleanup = StringDeduplicationCleanupDeadMinimum;
-  _dead_factor_for_cleanup = percent_of(StringDeduplicationCleanupDeadPercent, 100);
+  _dead_factor_for_cleanup = StringDeduplicationCleanupDeadPercent / 100.0;
   _hash_seed = initial_hash_seed();
 }


### PR DESCRIPTION
Clean backport to fix a math problem in strdedup heuristics that leads to observable memory leaks.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1` with `-XX:+UseStringDeduplication`
 - [x] Linux x86_64 fastdebug `tier2` with `-XX:+UseStringDeduplication`
 - [x] Linux x86_64 fastdebug `tier3` with `-XX:+UseStringDeduplication`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277981](https://bugs.openjdk.java.net/browse/JDK-8277981): String Deduplication table is never cleaned up due to bad dead_factor_for_cleanup


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/316/head:pull/316` \
`$ git checkout pull/316`

Update a local copy of the PR: \
`$ git checkout pull/316` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 316`

View PR using the GUI difftool: \
`$ git pr show -t 316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/316.diff">https://git.openjdk.java.net/jdk17u/pull/316.diff</a>

</details>
