### PR TITLE
8272167: AbsPathsInImage.java should skip *.dSYM directories

### DIFF
--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -144,6 +143,15 @@ public class AbsPathsInImage {
 
     private void scanFiles(Path root, List<byte[]> searchPatterns) throws IOException {
         Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                String dirName = dir.toString();
+                if (dirName.endsWith(".dSYM")) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return super.preVisitDirectory(dir, attrs);
+            }
+
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 String fileName = file.toString();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit dd93c6e2 from the openjdk/jdk repository.

The commit being backported was authored by Sergey Bylokhov on 12 Oct 2021 and was reviewed by Magnus Ihse Bursie and Erik Joelsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272167](https://bugs.openjdk.java.net/browse/JDK-8272167): AbsPathsInImage.java should skip *.dSYM directories


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/319/head:pull/319` \
`$ git checkout pull/319`

Update a local copy of the PR: \
`$ git checkout pull/319` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 319`

View PR using the GUI difftool: \
`$ git pr show -t 319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/319.diff">https://git.openjdk.java.net/jdk17u/pull/319.diff</a>

</details>
