### PR TITLE
8270874: JFrame paint artifacts when dragged from standard monitor to HiDPI monitor

### DIFF
--- a/test/jdk/java/awt/Window/WindowResizingOnDPIChanging/WindowResizingOnMovingToAnotherDisplay.java
+++ b/test/jdk/java/awt/Window/WindowResizingOnDPIChanging/WindowResizingOnMovingToAnotherDisplay.java
@@ -53,7 +53,7 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 
 /* @test
- * @bug 8147440 8147016
+ * @bug 8147440 8147016 8270874
  * @summary HiDPI (Windows): Swing components have incorrect sizes after
  *          changing display resolution
  * @run main/manual/othervm WindowResizingOnMovingToAnotherDisplay


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 03473b4c from the openjdk/jdk repository.

The commit being backported was authored by Sergey Bylokhov on 18 Nov 2021 and was reviewed by Jayathirth D V.

The jdk_desktop tests are green on the system where the bug was reproduced.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270874](https://bugs.openjdk.java.net/browse/JDK-8270874): JFrame paint artifacts when dragged from standard monitor to HiDPI monitor


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/320/head:pull/320` \
`$ git checkout pull/320`

Update a local copy of the PR: \
`$ git checkout pull/320` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 320`

View PR using the GUI difftool: \
`$ git pr show -t 320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/320.diff">https://git.openjdk.java.net/jdk17u/pull/320.diff</a>

</details>
