### PR TITLE
8277529: SIGSEGV in C2 CompilerThread Node::rematerialize() compiling Packet::readUnsignedTrint

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1626,14 +1626,7 @@ Node *LoadNode::split_through_phi(PhaseGVN *phase) {
       the_clone = x;            // Remember for possible deletion.
       // Alter data node to use pre-phi inputs
       if (this->in(0) == region) {
-        if (mem->is_Phi() && (mem->in(0) == region) && mem->in(i)->in(0) != NULL &&
-            MemNode::all_controls_dominate(address, region)) {
-          // Enable other optimizations such as loop predication which does not work
-          // if we directly pin the node to node `in`
-          x->set_req(0, mem->in(i)->in(0)); // Use same control as memory
-        } else {
-          x->set_req(0, in);
-        }
+        x->set_req(0, in);
       } else {
         x->set_req(0, NULL);
       }

--- a/test/hotspot/jtreg/compiler/loopopts/TestDepBetweenLoopAndPredicate.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDepBetweenLoopAndPredicate.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277529
+ * @summary RangeCheck should not be moved out of a loop if a node on the data input chain for the bool is dependent
+ *          on the projection into the loop (after the predicates).
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.loopopts.TestDepBetweenLoopAndPredicate::test*
+ *                   compiler.loopopts.TestDepBetweenLoopAndPredicate
+ */
+
+package compiler.loopopts;
+
+public class TestDepBetweenLoopAndPredicate {
+    static int x, y, z;
+    static boolean flag;
+    static int[] iArrFld = new int[25];
+    static int[] iArrFld2 = new int[5];
+    static int limit = 5;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            flag = !flag;
+            test();
+        }
+
+        for (int i = 0; i < 5000; i++) {
+            flag = !flag;
+            test2();
+            test3();
+            test4();
+            test5();
+        }
+    }
+
+    public static void test()  {
+        int[] iArr = new int[20];
+        System.arraycopy(iArrFld, x, iArr, y, 18);
+
+        if (flag) {
+            return;
+        }
+
+        for (int i = 0; i < limit; i++) {
+            iArr[19]++;
+        }
+    }
+
+    public static void test2() {
+        for (int i = 0; i < limit; i++) {
+            int[] iArr = new int[20];
+            System.arraycopy(iArrFld, x, iArr, y, 18);
+
+            if (flag) {
+                return;
+            }
+
+            for (int j = i; j < limit; j++) {
+                x = iArrFld[iArr[19]]; // No new offset node created
+                iArr[19]++;
+            }
+        }
+    }
+
+    public static void test3() {
+        for (int i = 0; i < limit; i++) {
+            int[] iArr = new int[20];
+            System.arraycopy(iArrFld, x, iArr, y, 18);
+
+            if (flag) {
+                return;
+            }
+
+            for (int j = i + 1; j < limit; j++) {
+                x = iArrFld[iArr[19]]; // New offset node created
+                iArr[19]++;
+            }
+        }
+    }
+
+    public static void test4() {
+        for (int i = 0; i < limit; i++) {
+            int[] iArr = new int[20];
+            System.arraycopy(iArrFld, x, iArr, y, 18);
+
+            if (flag) {
+                return;
+            }
+
+            for (int j = i + 1 + z; j < limit; j++) {
+                x = iArrFld[iArr[19]]; // New offset node created
+                iArr[19]++;
+            }
+        }
+    }
+
+    public static void test5() {
+        for (int i = 0; i < limit; i++) {
+            int[] iArr = new int[20];
+            System.arraycopy(iArrFld, x, iArr, y, 18);
+
+            if (flag) {
+                return;
+            }
+
+            for (int j = i + 1 + z; j < limit; j++) {
+                x = iArrFld[iArr[19]]; // New offset node created
+                iArr[19]++;
+                y += iArrFld2[3]; // Range check removed because not dependent on projection into the loop
+            }
+        }
+    }
+}


### PR DESCRIPTION
JDK-8277529
SIGSEGV in C2 CompilerThread Node::rematerialize() compiling Packet::readUnsignedTrint

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277529](https://bugs.openjdk.java.net/browse/JDK-8277529): SIGSEGV in C2 CompilerThread Node::rematerialize() compiling Packet::readUnsignedTrint


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/322/head:pull/322` \
`$ git checkout pull/322`

Update a local copy of the PR: \
`$ git checkout pull/322` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 322`

View PR using the GUI difftool: \
`$ git pr show -t 322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/322.diff">https://git.openjdk.java.net/jdk17u/pull/322.diff</a>

</details>
