### PR TITLE
8275608: runtime/Metaspace/elastic/TestMetaspaceAllocationMT2 too slow

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestArena.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestArena.java
@@ -25,8 +25,6 @@
 
 import sun.hotspot.WhiteBox;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 public class MetaspaceTestArena {
 
     long arena;
@@ -38,7 +36,7 @@ public class MetaspaceTestArena {
     long numAllocated = 0;
     long deallocatedWords = 0;
     long numDeallocated = 0;
-    long numAllocationFailures = 0;
+    volatile long numAllocationFailures = 0;
 
     private synchronized boolean reachedCeiling() {
         return (allocatedWords - deallocatedWords) > allocationCeiling;

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestManyArenasManyThreads.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestManyArenasManyThreads.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class MetaspaceTestManyArenasManyThreads extends MetaspaceTestWithThreads
             Thread.sleep(200);
 
             for (RandomAllocatorThread t: threads) {
-                if (t.allocator.arena.numAllocationFailures > 0) {
+                if (t.allocator.arena.numAllocationFailures > 1000) {
                     t.interrupt();
                     t.join();
                     context.destroyArena(t.allocator.arena);

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestWithThreads.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestWithThreads.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,6 @@
  * questions.
  *
  */
-
-import java.util.Set;
 
 public class MetaspaceTestWithThreads {
 
@@ -53,6 +51,8 @@ public class MetaspaceTestWithThreads {
         // Stop all threads.
         for (Thread t: threads) {
             t.interrupt();
+        }
+        for (Thread t: threads) {
             t.join();
         }
     }

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/RandomAllocator.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/RandomAllocator.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,11 @@ public class RandomAllocator {
     ArrayList<Allocation> to_dealloc = new ArrayList<>();
 
     long ticks = 0;
-    boolean allocationError = false;
+
+    // Allocate (breathe in) until arena is full, then - to test the arena deallocator - deallocate some allocations
+    // and breathe in again until full.
+    boolean breatheIn = true;
+    int breatheOutTicks = 0;
 
     Random localRandom;
 
@@ -57,7 +61,6 @@ public class RandomAllocator {
 
     // Allocate a random amount from the arena. If dice hits right, add this to the deallocation list.
     void allocateRandomly() {
-        allocationError = false;
         long word_size = profile.randomAllocationSize();
         Allocation a = arena.allocate(word_size);
         if (a != null) {
@@ -65,7 +68,9 @@ public class RandomAllocator {
                 to_dealloc.add(a);
             }
         } else {
-            allocationError = true;
+            // On allocation error, breathe out a bit
+            breatheIn = false;
+            breatheOutTicks = 0;
         }
     }
 
@@ -80,19 +85,20 @@ public class RandomAllocator {
     }
 
     public void tick() {
-
-        if (!allocationError) {
+        if (breatheIn) {
+            // allocate until we hit the ceiling
             allocateRandomly();
-            if(rollDice(profile.randomDeallocProbability)) {
+            if (rollDice(profile.randomDeallocProbability)) {
                deallocateRandomly();
             }
         } else {
-            deallocateRandomly();
-            allocationError = false;
+            if (++breatheOutTicks < 100) {
+                deallocateRandomly();
+            } else {
+                breatheIn = true;
+            }
         }
-
         ticks ++;
-
     }
 
     public RandomAllocator(MetaspaceTestArena arena) {
@@ -100,6 +106,10 @@ public class RandomAllocator {
         this.profile = AllocationProfile.randomProfile();
         // reproducable randoms (we assume each allocator is only used from within one thread, and gets created from the main thread).
         this.localRandom = new Random(RandomHelper.random().nextInt());
+    }
+
+    long numAllocationFailures() {
+        return arena.numAllocationFailures;
     }
 
     @Override

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/RandomAllocatorThread.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/RandomAllocatorThread.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
  *
  */
 
-import java.util.Random;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
@@ -55,9 +54,7 @@ public class RandomAllocatorThread extends Thread {
         }
 
         while (!Thread.interrupted()) {
-            for (int i = 0; i < 1000; i++) {
-                allocator.tick();
-            }
+            allocator.tick();
         }
 
         // System.out.println("+ [" + id + "] " + allocator);


### PR DESCRIPTION
Small patch to reduce the runtime of elastic metaspace tests, and make runtime more predictable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275608](https://bugs.openjdk.java.net/browse/JDK-8275608): runtime/Metaspace/elastic/TestMetaspaceAllocationMT2 too slow


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/326/head:pull/326` \
`$ git checkout pull/326`

Update a local copy of the PR: \
`$ git checkout pull/326` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 326`

View PR using the GUI difftool: \
`$ git pr show -t 326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/326.diff">https://git.openjdk.java.net/jdk17u/pull/326.diff</a>

</details>
