### PR TITLE
8278104: C1 should support the compiler directive 'BreakAtExecute'

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -355,7 +355,7 @@ void C1_MacroAssembler::remove_frame(int framesize) {
 }
 
 
-void C1_MacroAssembler::verified_entry() {
+void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.  For this action to be legal we
   // must ensure that this first instruction is a B, BL, NOP, BKPT,

--- a/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
@@ -70,8 +70,8 @@ void C1_MacroAssembler::remove_frame(int frame_size_in_bytes) {
   raw_pop(FP, LR);
 }
 
-void C1_MacroAssembler::verified_entry() {
-  if (C1Breakpoint) {
+void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
+  if (breakAtEntry) {
     breakpoint();
   }
 }

--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
@@ -87,8 +87,8 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
 }
 
 
-void C1_MacroAssembler::verified_entry() {
-  if (C1Breakpoint) illtrap();
+void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
+  if (breakAtEntry) illtrap();
   // build frame
 }
 

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -74,8 +74,8 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   push_frame(frame_size_in_bytes);
 }
 
-void C1_MacroAssembler::verified_entry() {
-  if (C1Breakpoint) z_illtrap(0xC1);
+void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
+  if (breakAtEntry) z_illtrap(0xC1);
 }
 
 void C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr, Label& slow_case) {

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -354,18 +354,18 @@ void C1_MacroAssembler::remove_frame(int frame_size_in_bytes) {
 }
 
 
-void C1_MacroAssembler::verified_entry() {
-  if (C1Breakpoint || VerifyFPU) {
+void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
+  if (breakAtEntry || VerifyFPU) {
     // Verified Entry first instruction should be 5 bytes long for correct
     // patching by patch_verified_entry().
     //
-    // C1Breakpoint and VerifyFPU have one byte first instruction.
+    // Breakpoint and VerifyFPU have one byte first instruction.
     // Also first instruction will be one byte "push(rbp)" if stack banging
     // code is not generated (see build_frame() above).
     // For all these cases generate long instruction first.
     fat_nop();
   }
-  if (C1Breakpoint)int3();
+  if (breakAtEntry) int3();
   // build frame
   IA32_ONLY( verify_FPU(0, "method_entry"); )
 }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -607,7 +607,7 @@ void LIR_Assembler::emit_op0(LIR_Op0* op) {
         check_icache();
       }
       offsets()->set_value(CodeOffsets::Verified_Entry, _masm->offset());
-      _masm->verified_entry();
+      _masm->verified_entry(compilation()->directive()->BreakAtExecuteOption);
       if (needs_clinit_barrier_on_entry(compilation()->method())) {
         clinit_barrier(compilation()->method());
       }

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ class C1_MacroAssembler: public MacroAssembler {
   void build_frame(int frame_size_in_bytes, int bang_size_in_bytes);
   void remove_frame(int frame_size_in_bytes);
 
-  void verified_entry();
+  void verified_entry(bool breakAtEntry);
   void verify_stack_oop(int offset) PRODUCT_RETURN;
   void verify_not_null_oop(Register r)  PRODUCT_RETURN;
 

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -334,9 +334,21 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
   if (!CompilerDirectivesIgnoreCompileCommandsOption && CompilerOracle::has_any_command_set()) {
     DirectiveSetPtr set(this);
 
+#ifdef COMPILER1
+    if (C1Breakpoint) {
+      // If the directives didn't have 'BreakAtExecute',
+      // the command 'C1Breakpoint' would become effective.
+      if (!_modified[BreakAtExecuteIndex]) {
+         set.cloned()->BreakAtExecuteOption = true;
+      }
+    }
+#endif
+
     // All CompileCommands are not equal so this gets a bit verbose
     // When CompileCommands have been refactored less clutter will remain.
     if (CompilerOracle::should_break_at(method)) {
+      // If the directives didn't have 'BreakAtCompile' or 'BreakAtExecute',
+      // the sub-command 'Break' of the 'CompileCommand' would become effective.
       if (!_modified[BreakAtCompileIndex]) {
         set.cloned()->BreakAtCompileOption = true;
       }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 3c10b5db from the openjdk/jdk repository.

The commit being backported was authored by Guoxiong Li on 18 Dec 2021 and was reviewed by Xin Liu, Paul Hohensee and Vladimir Kozlov.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278104](https://bugs.openjdk.java.net/browse/JDK-8278104): C1 should support the compiler directive 'BreakAtExecute'


### Reviewers
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/330/head:pull/330` \
`$ git checkout pull/330`

Update a local copy of the PR: \
`$ git checkout pull/330` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 330`

View PR using the GUI difftool: \
`$ git pr show -t 330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/330.diff">https://git.openjdk.java.net/jdk17u/pull/330.diff</a>

</details>
