### PR TITLE
8276990: Memory leak in invoker.c fillInvokeRequest() during JDI operations

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -232,6 +232,7 @@ fillInvokeRequest(JNIEnv *env, InvokeRequest *request,
     /*
      * Squirrel away the method signature
      */
+    JDI_ASSERT_MSG(request->methodSignature == NULL, "Request methodSignature not null");
     error = methodSignature(method, NULL, &request->methodSignature,  NULL);
     if (error != JVMTI_ERROR_NONE) {
         return error;
@@ -772,6 +773,10 @@ invoker_completeInvokeRequest(jthread thread)
      * after writing the respone.
      */
     deleteGlobalArgumentRefs(env, request);
+
+    JDI_ASSERT_MSG(request->methodSignature != NULL, "methodSignature is NULL");
+    jvmtiDeallocate(request->methodSignature);
+    request->methodSignature = NULL;
 
     /* From now on, do not access the request structure anymore
      * for this request id, because once we give up the invokerLock it may


### PR DESCRIPTION
Hi all,

This backports a fix for a memory leak in the JDWP.
The original change applies cleanly:

https://github.com/openjdk/jdk/commit/5ab22e88da8d79f9e19e8afffdd06206f42bab94

See issue:
https://bugs.openjdk.java.net/browse/JDK-8276990
and original PR:
https://github.com/openjdk/jdk/pull/7306

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276990](https://bugs.openjdk.java.net/browse/JDK-8276990): Memory leak in invoker.c fillInvokeRequest() during JDI operations ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/334/head:pull/334` \
`$ git checkout pull/334`

Update a local copy of the PR: \
`$ git checkout pull/334` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 334`

View PR using the GUI difftool: \
`$ git pr show -t 334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/334.diff">https://git.openjdk.java.net/jdk17u/pull/334.diff</a>

</details>
