### PR TITLE
8282444: Module finder incorrectly assumes default file system path-separator character

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/ModulePath.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -663,11 +663,12 @@ public class ModulePath implements ModuleFinder {
     // -- exploded directories --
 
     private Set<String> explodedPackages(Path dir) {
+        String separator = dir.getFileSystem().getSeparator();
         try {
             return Files.find(dir, Integer.MAX_VALUE,
                     ((path, attrs) -> attrs.isRegularFile() && !isHidden(path)))
                     .map(path -> dir.relativize(path))
-                    .map(this::toPackageName)
+                    .map(path -> toPackageName(path, separator))
                     .flatMap(Optional::stream)
                     .collect(Collectors.toSet());
         } catch (IOException x) {
@@ -738,7 +739,7 @@ public class ModulePath implements ModuleFinder {
      * @throws InvalidModuleDescriptorException if the name is a class file in
      *         the top-level directory (and it's not module-info.class)
      */
-    private Optional<String> toPackageName(Path file) {
+    private Optional<String> toPackageName(Path file, String separator) {
         assert file.getRoot() == null;
 
         Path parent = file.getParent();
@@ -752,7 +753,7 @@ public class ModulePath implements ModuleFinder {
             return Optional.empty();
         }
 
-        String pn = parent.toString().replace(File.separatorChar, '.');
+        String pn = parent.toString().replace(separator, ".");
         if (Checks.isPackageName(pn)) {
             return Optional.of(pn);
         } else {

--- a/test/jdk/java/lang/module/customfs/ModulesInCustomFileSystem.java
+++ b/test/jdk/java/lang/module/customfs/ModulesInCustomFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8178380 8282444
  * @modules jdk.zipfs
  * @library /test/lib
  * @build ModulesInCustomFileSystem m1/* m2/*

--- a/test/jdk/java/lang/module/customfs/m1/p/Main.java
+++ b/test/jdk/java/lang/module/customfs/m1/p/Main.java
@@ -25,6 +25,6 @@ package p;
 
 public class Main {
     public static void main(String[] args) {
-        q.Hello.hello();
+        q.r.Hello.hello();
     }
 }

--- a/test/jdk/java/lang/module/customfs/m2/module-info.java
+++ b/test/jdk/java/lang/module/customfs/m2/module-info.java
@@ -22,5 +22,5 @@
  */
 
 module m2 {
-    exports q;
+    exports q.r;
 }

--- a/test/jdk/java/lang/module/customfs/m2/q/r/Hello.java
+++ b/test/jdk/java/lang/module/customfs/m2/q/r/Hello.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package q;
+package q.r;
 
 public class Hello {
     public static void hello() {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282444](https://bugs.openjdk.java.net/browse/JDK-8282444): Module finder incorrectly assumes default file system path-separator character


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/336/head:pull/336` \
`$ git checkout pull/336`

Update a local copy of the PR: \
`$ git checkout pull/336` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 336`

View PR using the GUI difftool: \
`$ git pr show -t 336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/336.diff">https://git.openjdk.java.net/jdk17u/pull/336.diff</a>

</details>
