### PR TITLE
8287162: (zipfs) Performance regression related to support for POSIX file permissions

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -151,9 +151,9 @@ class ZipFileSystem extends FileSystem {
         this.forceEnd64 = isTrue(env, "forceZIP64End");
         this.defaultCompressionMethod = getDefaultCompressionMethod(env);
         this.supportPosix = isTrue(env, PROPERTY_POSIX);
-        this.defaultOwner = initOwner(zfpath, env);
-        this.defaultGroup = initGroup(zfpath, env);
-        this.defaultPermissions = initPermissions(env);
+        this.defaultOwner = supportPosix ? initOwner(zfpath, env) : null;
+        this.defaultGroup = supportPosix ? initGroup(zfpath, env) : null;
+        this.defaultPermissions = supportPosix ? initPermissions(env) : null;
         this.supportedFileAttributeViews = supportPosix ?
             Set.of("basic", "posix", "zip") : Set.of("basic", "zip");
         if (Files.notExists(zfpath)) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8287162](https://bugs.openjdk.java.net/browse/JDK-8287162), commit [a10c5597](https://github.com/openjdk/jdk/commit/a10c5597d93c4402bafdbb570437aac052b10027) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Lance Andersen on 24 May 2022 and was reviewed by Jaikiran Pai, Alan Bateman and Christoph Langer.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287162](https://bugs.openjdk.java.net/browse/JDK-8287162): (zipfs) Performance regression related to support for POSIX file permissions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u pull/342/head:pull/342` \
`$ git checkout pull/342`

Update a local copy of the PR: \
`$ git checkout pull/342` \
`$ git pull https://git.openjdk.java.net/jdk17u pull/342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 342`

View PR using the GUI difftool: \
`$ git pr show -t 342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u/pull/342.diff">https://git.openjdk.java.net/jdk17u/pull/342.diff</a>

</details>
