### PR TITLE
8283903: GetContainerCpuLoad does not return the correct result in share mode

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
                 int totalCPUs = getHostOnlineCpuCount0();
                 int containerCPUs = getAvailableProcessors();
                 // scale the total host load to the actual container cpus
-                hostTicks = hostTicks * containerCPUs / totalCPUs;
+                double scaleFactor = ((double) containerCPUs) / totalCPUs;
+                hostTicks = (long) (hostTicks * scaleFactor);
                 return getUsageDividesTotal(cpuUsageSupplier().getAsLong(), hostTicks);
             } else {
                 // If CPU quotas and shares are not active then find the average load for


### PR DESCRIPTION
Backport a625bfdba45d49bc717bcc9be4112db93b50f50a

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283903](https://bugs.openjdk.org/browse/JDK-8283903): GetContainerCpuLoad does not return the correct result in share mode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u pull/351/head:pull/351` \
`$ git checkout pull/351`

Update a local copy of the PR: \
`$ git checkout pull/351` \
`$ git pull https://git.openjdk.org/jdk17u pull/351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 351`

View PR using the GUI difftool: \
`$ git pr show -t 351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/351.diff">https://git.openjdk.org/jdk17u/pull/351.diff</a>

</details>
