### PR TITLE
8275887: jarsigner prints invalid digest/signature algorithm warnings if keysize is weak/disabled

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
@@ -76,10 +76,12 @@ public class SignerInfo implements DerEncoder {
     /**
      * A map containing the algorithms in this SignerInfo. This is used to
      * avoid checking algorithms to see if they are disabled more than once.
-     * The key is the AlgorithmId of the algorithm, and the value is the name of
-     * the field or attribute.
+     * The key is the AlgorithmId of the algorithm, and the value is a record
+     * containing the name of the field or attribute and whether the key
+     * should also be checked (ex: if it is a signature algorithm).
      */
-    private Map<AlgorithmId, String> algorithms = new HashMap<>();
+    private record AlgorithmInfo(String field, boolean checkKey) {}
+    private Map<AlgorithmId, AlgorithmInfo> algorithms = new HashMap<>();
 
     public SignerInfo(X500Name  issuerName,
                       BigInteger serial,
@@ -350,7 +352,8 @@ public class SignerInfo implements DerEncoder {
             }
 
             String digestAlgName = digestAlgorithmId.getName();
-            algorithms.put(digestAlgorithmId, "SignerInfo digestAlgorithm field");
+            algorithms.put(digestAlgorithmId,
+                new AlgorithmInfo("SignerInfo digestAlgorithm field", false));
 
             byte[] dataSigned;
 
@@ -428,7 +431,8 @@ public class SignerInfo implements DerEncoder {
                     new AlgorithmId(ObjectIdentifier.of(oid),
                             digestEncryptionAlgorithmId.getParameters());
                 algorithms.put(sigAlgId,
-                    "SignerInfo digestEncryptionAlgorithm field");
+                    new AlgorithmInfo(
+                        "SignerInfo digestEncryptionAlgorithm field", true));
             }
 
             X509Certificate cert = getCertificate(block);
@@ -685,7 +689,8 @@ public class SignerInfo implements DerEncoder {
         throws NoSuchAlgorithmException, SignatureException {
 
         AlgorithmId digestAlgId = token.getHashAlgorithm();
-        algorithms.put(digestAlgId, "TimestampToken digestAlgorithm field");
+        algorithms.put(digestAlgId,
+            new AlgorithmInfo("TimestampToken digestAlgorithm field", false));
 
         MessageDigest md = MessageDigest.getInstance(digestAlgId.getName());
 
@@ -742,18 +747,19 @@ public class SignerInfo implements DerEncoder {
      */
     public static Set<String> verifyAlgorithms(SignerInfo[] infos,
         JarConstraintsParameters params, String name) throws SignatureException {
-        Map<AlgorithmId, String> algorithms = new HashMap<>();
+        Map<AlgorithmId, AlgorithmInfo> algorithms = new HashMap<>();
         for (SignerInfo info : infos) {
             algorithms.putAll(info.algorithms);
         }
 
         Set<String> enabledAlgorithms = new HashSet<>();
         try {
-            for (Map.Entry<AlgorithmId, String> algorithm : algorithms.entrySet()) {
-                params.setExtendedExceptionMsg(name, algorithm.getValue());
-                AlgorithmId algId = algorithm.getKey();
+            for (var algEntry : algorithms.entrySet()) {
+                AlgorithmInfo info = algEntry.getValue();
+                params.setExtendedExceptionMsg(name, info.field());
+                AlgorithmId algId = algEntry.getKey();
                 JAR_DISABLED_CHECK.permits(algId.getName(),
-                    algId.getParameters(), params);
+                    algId.getParameters(), params, info.checkKey());
                 enabledAlgorithms.add(algId.getName());
             }
         } catch (CertPathValidatorException e) {

--- a/src/java.base/share/classes/sun/security/provider/certpath/AlgorithmChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/AlgorithmChecker.java
@@ -38,7 +38,6 @@ import java.security.KeyFactory;
 import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
 import java.security.cert.Certificate;
-import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.security.cert.PKIXCertPathChecker;
 import java.security.cert.TrustAnchor;
@@ -57,7 +56,6 @@ import sun.security.util.DisabledAlgorithmConstraints;
 import sun.security.validator.Validator;
 import sun.security.x509.AlgorithmId;
 import sun.security.x509.X509CertImpl;
-import sun.security.x509.X509CRLImpl;
 
 /**
  * A {@code PKIXCertPathChecker} implementation to check whether a
@@ -285,13 +283,13 @@ public final class AlgorithmChecker extends PKIXCertPathChecker {
         // Check against local constraints if it is DisabledAlgorithmConstraints
         if (constraints instanceof DisabledAlgorithmConstraints) {
             ((DisabledAlgorithmConstraints)constraints).permits(currSigAlg,
-                currSigAlgParams, cp);
+                currSigAlgParams, cp, true);
             // DisabledAlgorithmsConstraints does not check primitives, so key
             // additional key check.
 
         } else {
             // Perform the default constraints checking anyway.
-            certPathDefaultConstraints.permits(currSigAlg, currSigAlgParams, cp);
+            certPathDefaultConstraints.permits(currSigAlg, currSigAlgParams, cp, true);
             // Call locally set constraints to check key with primitives.
             if (!constraints.permits(primitives, currPubKey)) {
                 throw new CertPathValidatorException(
@@ -381,29 +379,6 @@ public final class AlgorithmChecker extends PKIXCertPathChecker {
      * Check the signature algorithm with the specified public key.
      *
      * @param key the public key to verify the CRL signature
-     * @param crl the target CRL
-     * @param variant the Validator variant of the operation. A null value
-     *                passed will set it to Validator.GENERIC.
-     * @param anchor the trust anchor selected to validate the CRL issuer
-     */
-    static void check(PublicKey key, X509CRL crl, String variant,
-                      TrustAnchor anchor) throws CertPathValidatorException {
-
-        X509CRLImpl x509CRLImpl = null;
-        try {
-            x509CRLImpl = X509CRLImpl.toImpl(crl);
-        } catch (CRLException ce) {
-            throw new CertPathValidatorException(ce);
-        }
-
-        AlgorithmId algorithmId = x509CRLImpl.getSigAlgId();
-        check(key, algorithmId, variant, anchor);
-    }
-
-    /**
-     * Check the signature algorithm with the specified public key.
-     *
-     * @param key the public key to verify the CRL signature
      * @param algorithmId signature algorithm Algorithm ID
      * @param variant the Validator variant of the operation. A null
      *                value passed will set it to Validator.GENERIC.
@@ -414,7 +389,7 @@ public final class AlgorithmChecker extends PKIXCertPathChecker {
 
         certPathDefaultConstraints.permits(algorithmId.getName(),
             algorithmId.getParameters(),
-            new CertPathConstraintsParameters(key, variant, anchor));
+            new CertPathConstraintsParameters(key, variant, anchor), true);
     }
 }
 

--- a/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -691,7 +691,8 @@ public class DistributionPointFetcher {
 
         // check the crl signature algorithm
         try {
-            AlgorithmChecker.check(prevKey, crl, variant, anchor);
+            AlgorithmChecker.check(prevKey, crlImpl.getSigAlgId(),
+                                   variant, anchor);
         } catch (CertPathValidatorException cpve) {
             if (debug != null) {
                 debug.println("CRL signature algorithm check failed: " + cpve);

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -199,16 +199,16 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
     }
 
     public final void permits(String algorithm, AlgorithmParameters ap,
-        ConstraintsParameters cp) throws CertPathValidatorException {
-
-        permits(algorithm, cp);
+            ConstraintsParameters cp, boolean checkKey)
+            throws CertPathValidatorException {
+        permits(algorithm, cp, checkKey);
         if (ap != null) {
             permits(ap, cp);
         }
     }
 
     private void permits(AlgorithmParameters ap, ConstraintsParameters cp)
-        throws CertPathValidatorException {
+            throws CertPathValidatorException {
 
         switch (ap.getAlgorithm().toUpperCase(Locale.ENGLISH)) {
             case "RSASSA-PSS":
@@ -226,13 +226,13 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             PSSParameterSpec pssParams =
                 ap.getParameterSpec(PSSParameterSpec.class);
             String digestAlg = pssParams.getDigestAlgorithm();
-            permits(digestAlg, cp);
+            permits(digestAlg, cp, false);
             AlgorithmParameterSpec mgfParams = pssParams.getMGFParameters();
             if (mgfParams instanceof MGF1ParameterSpec) {
                 String mgfDigestAlg =
                     ((MGF1ParameterSpec)mgfParams).getDigestAlgorithm();
                 if (!mgfDigestAlg.equalsIgnoreCase(digestAlg)) {
-                    permits(mgfDigestAlg, cp);
+                    permits(mgfDigestAlg, cp, false);
                 }
             }
         } catch (InvalidParameterSpecException ipse) {
@@ -240,22 +240,24 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
         }
     }
 
-    public final void permits(String algorithm, ConstraintsParameters cp)
-            throws CertPathValidatorException {
+    public final void permits(String algorithm, ConstraintsParameters cp,
+            boolean checkKey) throws CertPathValidatorException {
 
-        // Check if named curves in the key are disabled.
-        for (Key key : cp.getKeys()) {
-            for (String curve : getNamedCurveFromKey(key)) {
-                if (!cachedCheckAlgorithm(curve)) {
-                    throw new CertPathValidatorException(
+        if (checkKey) {
+            // Check if named curves in the key are disabled.
+            for (Key key : cp.getKeys()) {
+                for (String curve : getNamedCurveFromKey(key)) {
+                    if (!cachedCheckAlgorithm(curve)) {
+                        throw new CertPathValidatorException(
                             "Algorithm constraints check failed on disabled " +
                                     "algorithm: " + curve,
                             null, null, -1, BasicReason.ALGORITHM_CONSTRAINED);
+                    }
                 }
             }
         }
 
-        algorithmConstraints.permits(algorithm, cp);
+        algorithmConstraints.permits(algorithm, cp, checkKey);
     }
 
     private static List<String> getNamedCurveFromKey(Key key) {
@@ -493,8 +495,8 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             return true;
         }
 
-        public void permits(String algorithm, ConstraintsParameters cp)
-                throws CertPathValidatorException {
+        public void permits(String algorithm, ConstraintsParameters cp,
+                boolean checkKey) throws CertPathValidatorException {
 
             if (debug != null) {
                 debug.println("Constraints.permits(): " + algorithm + ", "
@@ -508,8 +510,10 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                 algorithms.add(algorithm);
             }
 
-            for (Key key : cp.getKeys()) {
-                algorithms.add(key.getAlgorithm());
+            if (checkKey) {
+                for (Key key : cp.getKeys()) {
+                    algorithms.add(key.getAlgorithm());
+                }
             }
 
             // Check all applicable constraints
@@ -519,6 +523,9 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                     continue;
                 }
                 for (Constraint constraint : list) {
+                    if (!checkKey && constraint instanceof KeySizeConstraint) {
+                        continue;
+                    }
                     constraint.permits(cp);
                 }
             }

--- a/src/java.base/share/classes/sun/security/util/JarConstraintsParameters.java
+++ b/src/java.base/share/classes/sun/security/util/JarConstraintsParameters.java
@@ -98,16 +98,11 @@ public class JarConstraintsParameters implements ConstraintsParameters {
         this.timestamp = latestTimestamp;
     }
 
-    public JarConstraintsParameters(List<X509Certificate> chain, Timestamp timestamp) {
+    public JarConstraintsParameters(List<X509Certificate> chain, Date timestamp) {
         this.keys = new HashSet<>();
         this.certsIssuedByAnchor = new HashSet<>();
         addToCertsAndKeys(chain);
-        if (timestamp != null) {
-            addToCertsAndKeys(timestamp.getSignerCertPath());
-            this.timestamp = timestamp.getTimestamp();
-        } else {
-            this.timestamp = null;
-        }
+        this.timestamp = timestamp;
     }
 
     // extract last certificate and signer's public key from chain
@@ -178,7 +173,7 @@ public class JarConstraintsParameters implements ConstraintsParameters {
 
     @Override
     public String extendedExceptionMsg() {
-        return message;
+        return message == null ? "." : message;
     }
 
     @Override

--- a/src/java.base/share/classes/sun/security/util/ManifestEntryVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/ManifestEntryVerifier.java
@@ -295,7 +295,7 @@ public class ManifestEntryVerifier {
             params.setExtendedExceptionMsg(JarFile.MANIFEST_NAME,
                 name + " entry");
             DisabledAlgorithmConstraints.jarConstraints()
-                   .permits(algorithm, params);
+                .permits(algorithm, params, false);
             return true;
         } catch (GeneralSecurityException e) {
             if (debug != null) {

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -383,7 +383,7 @@ public class SignatureFileVerifier {
             try {
                 params.setExtendedExceptionMsg(name + ".SF", key + " attribute");
                 DisabledAlgorithmConstraints
-                    .jarConstraints().permits(algorithm, params);
+                    .jarConstraints().permits(algorithm, params, false);
             } catch (GeneralSecurityException e) {
                 permittedAlgs.put(algorithm, Boolean.FALSE);
                 permittedAlgs.put(key.toUpperCase(), Boolean.FALSE);

--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -55,7 +55,7 @@ import sun.security.timestamp.TimestampToken;
 /*
  * @test
  * @bug 6543842 6543440 6939248 8009636 8024302 8163304 8169911 8180289 8172404
- *      8247960 8242068 8269039
+ *      8247960 8242068 8269039 8275887
  * @summary checking response of timestamp
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.timestamp
@@ -340,6 +340,7 @@ public class TimestampCheck {
                 verify("tsdisabled2.jar", "-verbose")
                         .shouldHaveExitValue(16)
                         .shouldContain("treated as unsigned")
+                        .shouldNotMatch("Signature.*(disabled)")
                         .shouldMatch("Timestamp.*512.*(disabled)");
 
                 // Algorithm used in signing is disabled
@@ -356,6 +357,8 @@ public class TimestampCheck {
                 // sign with RSAkeysize < 1024
                 signVerbose("normal", "sign1.jar", "sign2.jar", "disabledkeysize")
                         .shouldContain("Algorithm constraints check failed on keysize")
+                        .shouldNotContain("option is considered a security " +
+                            "risk and is disabled")
                         .shouldHaveExitValue(4);
                 checkMultiple("sign2.jar");
 
@@ -419,6 +422,17 @@ public class TimestampCheck {
                 // sign with RSAkeysize < 2048
                 signVerbose("normal", "sign1.jar", "sign2.jar", "weakkeysize")
                         .shouldNotContain("Algorithm constraints check failed on keysize")
+                        .shouldNotContain("The SHA-256 algorithm specified " +
+                            "for the -digestalg option is considered a " +
+                            "security risk")
+                        .shouldNotContain("The SHA256withRSA algorithm " +
+                            "specified for the -sigalg option is considered " +
+                            "a security risk")
+                        .shouldNotContain("The SHA-256 algorithm specified " +
+                            "for the -tsadigestalg option is considered a " +
+                            "security risk")
+                        .shouldContain("The RSA signing key has a keysize " +
+                            "of 1024 which is considered a security risk")
                         .shouldHaveExitValue(0);
                 checkMultipleWeak("sign2.jar");
 
@@ -673,7 +687,7 @@ public class TimestampCheck {
                 .shouldMatch("Timestamp signature algorithm: .*key.*(disabled)");
         verify(file, "-J-Djava.security.debug=jar")
                 .shouldHaveExitValue(16)
-                .shouldMatch("SignatureException:.*keysize");
+                .shouldMatch("SignatureException:.*MD5");
 
         // For 8171319: keytool should print out warnings when reading or
         //              generating cert/cert req using disabled algorithms.


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

I had to resolve the change in a few places:

src/java.base/share/classes/sun/security/provider/certpath/AlgorithmChecker.java
Where "true" is added to permits() call, code looks different. This is because
"8243585: AlgorithmChecker::check throws confusing exception when it rejects the signer key"
is not backported.
Added true to all calls of permits().

src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
Method permits() has a slightly different implementation in 17.
The new parameter is just switching off the check. I
wrapped the check around the code in 17 as in the original.

src/java.base/share/classes/sun/security/util/ManifestEntryVerifier.java
Copyright
Call to permits() has different argument.

It already ran successful through our nightly testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275887](https://bugs.openjdk.org/browse/JDK-8275887): jarsigner prints invalid digest/signature algorithm warnings if keysize is weak/disabled


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u pull/354/head:pull/354` \
`$ git checkout pull/354`

Update a local copy of the PR: \
`$ git checkout pull/354` \
`$ git pull https://git.openjdk.org/jdk17u pull/354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 354`

View PR using the GUI difftool: \
`$ git pr show -t 354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/354.diff">https://git.openjdk.org/jdk17u/pull/354.diff</a>

</details>
