### PR TITLE
EA/SR - Simplify some object allocation

### DIFF
--- a/src/hotspot/share/libadt/dict.hpp
+++ b/src/hotspot/share/libadt/dict.hpp
@@ -93,7 +93,7 @@ int32_t cmpkey(const void* key1, const void* key2);
 //------------------------------Iteration--------------------------------------
 // The class of dictionary iterators.  Fails in the presences of modifications
 // to the dictionary during iteration (including searches).
-// Usage:  for( DictI i(dict); i.test(); ++i ) { body = i.key; body = i.value;}
+// Usage:  for( DictI i(dict); i.test(); ++i ) { body = i._key; body = i._value;}
 class DictI {
  private:
   const Dict* _d;               // Dictionary being iterated over

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -471,6 +471,12 @@
   develop(bool, TracePostallocExpand, false, "Trace expanding nodes after"  \
           " register allocation.")                                          \
                                                                             \
+  product(bool, ReduceAllocationMerges, false, EXPERIMENTAL,                \
+          "Try to simplify allocation merges before Scalar Replacement")    \
+                                                                            \
+  develop(bool, TraceReduceAllocationMerges, false,                         \
+          "Trace decision for simplifying allocation merges.")              \
+                                                                            \
   product(bool, DoEscapeAnalysis, true,                                     \
           "Perform escape analysis")                                        \
                                                                             \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -48,6 +48,12 @@ const char* C2Compiler::retry_no_escape_analysis() {
 const char* C2Compiler::retry_no_locks_coarsening() {
   return "retry without locks coarsening";
 }
+const char* C2Compiler::retry_no_iterative_escape_analysis() {
+  return "retry without iterative escape analysis";
+}
+const char* C2Compiler::retry_no_reduce_allocation_merges() {
+  return "retry without trying to reduce allocation merges";
+}
 const char* C2Compiler::retry_class_loading_during_parsing() {
   return "retry class loading during parsing";
 }
@@ -99,12 +105,16 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
 
   bool subsume_loads = SubsumeLoads;
   bool do_escape_analysis = DoEscapeAnalysis;
+  bool do_iterative_escape_analysis = DoEscapeAnalysis;
+  bool do_reduce_allocation_merges = ReduceAllocationMerges;
   bool eliminate_boxing = EliminateAutoBox;
   bool do_locks_coarsening = EliminateLocks;
 
   while (!env->failing()) {
-    // Attempt to compile while subsuming loads into machine instructions.
-    Compile C(env, target, entry_bci, subsume_loads, do_escape_analysis, eliminate_boxing, do_locks_coarsening, install_code, directive);
+    Options options(subsume_loads, do_escape_analysis, do_iterative_escape_analysis,
+                    do_reduce_allocation_merges, eliminate_boxing, do_locks_coarsening,
+                    install_code);
+    Compile C(env, target, entry_bci, options, directive);
 
     // Check result and retry if appropriate.
     if (C.failure_reason() != NULL) {
@@ -121,6 +131,18 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
       if (C.failure_reason_is(retry_no_escape_analysis())) {
         assert(do_escape_analysis, "must make progress");
         do_escape_analysis = false;
+        env->report_failure(C.failure_reason());
+        continue;  // retry
+      }
+      if (C.failure_reason_is(retry_no_iterative_escape_analysis())) {
+        assert(do_iterative_escape_analysis, "must make progress");
+        do_iterative_escape_analysis = false;
+        env->report_failure(C.failure_reason());
+        continue;  // retry
+      }
+      if (C.failure_reason_is(retry_no_reduce_allocation_merges())) {
+        assert(do_reduce_allocation_merges, "must make progress");
+        do_reduce_allocation_merges = false;
         env->report_failure(C.failure_reason());
         continue;  // retry
       }

--- a/src/hotspot/share/opto/c2compiler.hpp
+++ b/src/hotspot/share/opto/c2compiler.hpp
@@ -49,6 +49,8 @@ public:
   // sentinel value used to trigger backtracking in compile_method().
   static const char* retry_no_subsuming_loads();
   static const char* retry_no_escape_analysis();
+  static const char* retry_no_iterative_escape_analysis();
+  static const char* retry_no_reduce_allocation_merges();
   static const char* retry_no_locks_coarsening();
   static const char* retry_class_loading_during_parsing();
 

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -125,17 +125,18 @@ static Node *merge_region(RegionNode *region, PhaseGVN *phase) {
 
 
 //--------------------------------has_phi--------------------------------------
-// Helper function: Return any PhiNode that uses this region or NULL
-PhiNode* RegionNode::has_phi() const {
+// Helper function: Return true if there is any PhiNode or ReducedAllocationMerge
+// using this region node.
+bool RegionNode::has_phi() const {
   for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
     Node* phi = fast_out(i);
-    if (phi->is_Phi()) {   // Check for Phi users
+    if (phi->is_Phi() || phi->is_ReducedAllocationMerge()) {
       assert(phi->in(0) == (Node*)this, "phi uses region only via in(0)");
-      return phi->as_Phi();  // this one is good enough
+      return true;
     }
   }
 
-  return NULL;
+  return false;
 }
 
 
@@ -447,7 +448,7 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // arm of the same IF.  If found, then the control-flow split is useless.
   bool has_phis = false;
   if (can_reshape) {            // Need DU info to check for Phi users
-    has_phis = (has_phi() != NULL);       // Cache result
+    has_phis = has_phi();       // Cache result
     if (has_phis && try_clean_mem_phi(phase)) {
       has_phis = false;
     }

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -86,7 +86,7 @@ public:
       return nonnull_req();
     return NULL;  // not a copy!
   }
-  PhiNode* has_phi() const;        // returns an arbitrary phi user, or NULL
+  bool has_phi() const;        // returns true if there is a Phi or RAM use of this region
   PhiNode* has_unique_phi() const; // returns the unique phi user, or NULL
   // Is this region node unreachable from root?
   bool is_unreachable_region(const PhaseGVN* phase);

--- a/src/hotspot/share/opto/classes.hpp
+++ b/src/hotspot/share/opto/classes.hpp
@@ -286,6 +286,7 @@ macro(RotateLeft)
 macro(RotateLeftV)
 macro(RotateRight)
 macro(RotateRightV)
+macro(ReducedAllocationMerge)
 macro(SafePoint)
 macro(SafePointScalarObject)
 #if INCLUDE_SHENANDOAHGC

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -162,6 +162,45 @@ class CloneMap {
   bool same_gen(node_idx_t k1, node_idx_t k2)  const { return gen(k1) == gen(k2); }
 };
 
+class Options {
+  friend class Compile;
+  friend class VMStructs;
+ private:
+  const bool _subsume_loads;         // Load can be matched as part of a larger op.
+  const bool _do_escape_analysis;    // Do escape analysis.
+  const bool _do_iterative_escape_analysis;  // Do iterative escape analysis.
+  const bool _do_reduce_allocation_merges;   // Do try to reduce allocation merges.
+  const bool _eliminate_boxing;      // Do boxing elimination.
+  const bool _do_locks_coarsening;   // Do locks coarsening
+  const bool _install_code;          // Install the code that was compiled
+ public:
+  Options(bool subsume_loads, bool do_escape_analysis,
+          bool do_iterative_escape_analysis,
+          bool do_reduce_allocation_merges,
+          bool eliminate_boxing, bool do_locks_coarsening,
+          bool install_code) :
+          _subsume_loads(subsume_loads),
+          _do_escape_analysis(do_escape_analysis),
+          _do_iterative_escape_analysis(do_iterative_escape_analysis),
+          _do_reduce_allocation_merges(do_reduce_allocation_merges),
+          _eliminate_boxing(eliminate_boxing),
+          _do_locks_coarsening(do_locks_coarsening),
+          _install_code(install_code) {
+  }
+
+  static Options for_runtime_stub() {
+    return Options(
+       /* subsume_loads = */ true,
+       /* do_escape_analysis = */ false,
+       /* do_iterative_escape_analysis = */ false,
+       /* do_reduce_allocation_merges = */ false,
+       /* eliminate_boxing = */ false,
+       /* do_lock_coarsening = */ false,
+       /* install_code = */ true
+    );
+  }
+};
+
 //------------------------------Compile----------------------------------------
 // This class defines a top-level Compiler invocation.
 
@@ -246,11 +285,7 @@ class Compile : public Phase {
  private:
   // Fixed parameters to this compilation.
   const int             _compile_id;
-  const bool            _subsume_loads;         // Load can be matched as part of a larger op.
-  const bool            _do_escape_analysis;    // Do escape analysis.
-  const bool            _install_code;          // Install the code that was compiled
-  const bool            _eliminate_boxing;      // Do boxing elimination.
-  const bool            _do_locks_coarsening;   // Do locks coarsening
+  const Options         _options;               // Compilation options
   ciMethod*             _method;                // The method being compiled.
   int                   _entry_bci;             // entry bci for osr methods.
   const TypeFunc*       _tf;                    // My kind of signature
@@ -504,16 +539,18 @@ class Compile : public Phase {
   // Does this compilation allow instructions to subsume loads?  User
   // instructions that subsume a load may result in an unschedulable
   // instruction sequence.
-  bool              subsume_loads() const       { return _subsume_loads; }
+  bool              subsume_loads() const       { return _options._subsume_loads; }
   /** Do escape analysis. */
-  bool              do_escape_analysis() const  { return _do_escape_analysis; }
+  bool              do_escape_analysis() const  { return _options._do_escape_analysis; }
+  bool              do_iterative_escape_analysis() const  { return _options._do_iterative_escape_analysis; }
+  bool              do_reduce_allocation_merges() const  { return _options._do_reduce_allocation_merges; }
   /** Do boxing elimination. */
-  bool              eliminate_boxing() const    { return _eliminate_boxing; }
+  bool              eliminate_boxing() const    { return _options._eliminate_boxing; }
   /** Do aggressive boxing elimination. */
-  bool              aggressive_unboxing() const { return _eliminate_boxing && AggressiveUnboxing; }
-  bool              should_install_code() const { return _install_code; }
+  bool              aggressive_unboxing() const { return _options._eliminate_boxing && AggressiveUnboxing; }
+  bool              should_install_code() const { return _options._install_code; }
   /** Do locks coarsening. */
-  bool              do_locks_coarsening() const { return _do_locks_coarsening; }
+  bool              do_locks_coarsening() const { return _options._do_locks_coarsening; }
 
   // Other fixed compilation parameters.
   ciMethod*         method() const              { return _method; }
@@ -1034,9 +1071,7 @@ class Compile : public Phase {
   // replacement, entry_bci indicates the bytecode for which to compile a
   // continuation.
   Compile(ciEnv* ci_env, ciMethod* target,
-          int entry_bci, bool subsume_loads, bool do_escape_analysis,
-          bool eliminate_boxing, bool do_locks_coarsening,
-          bool install_code, DirectiveSet* directive);
+          int entry_bci, Options options, DirectiveSet* directive);
 
   // Second major entry point.  From the TypeFunc signature, generate code
   // to pass arguments from the Java calling convention to the C calling

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -822,7 +822,7 @@ bool IfNode::has_only_uncommon_traps(ProjNode* proj, ProjNode*& success, ProjNod
         if (r->outcnt() != 2 || r->req() != 3 || r->find_edge(otherproj) == -1 || r->find_edge(unc_proj) == -1) {
           return false;
         }
-        assert(r->has_phi() == NULL, "simple region shouldn't have a phi");
+        assert(!r->has_phi(), "simple region shouldn't have a phi");
       } else if (dom_unc->in(0) != otherproj || unc->in(0) != unc_proj) {
         return false;
       }

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -100,9 +100,24 @@ private:
 
   bool eliminate_boxing_node(CallStaticJavaNode *boxing);
   bool eliminate_allocate_node(AllocateNode *alloc);
-  bool can_eliminate_allocation(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints);
-  bool scalar_replacement(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints_done);
+  bool can_eliminate_allocation(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints, GrowableArray <ReducedAllocationMergeNode *>& rams);
   void process_users_of_allocation(CallNode *alloc);
+
+  // Effectivelly performs scalar replacement by replacing the uses of 'alloc' in
+  // the nodes in 'safepoints' and 'rams' by a SafePointScalarObjectNode.
+  bool scalar_replacement(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints_done, GrowableArray <ReducedAllocationMergeNode *>& rams);
+
+  // This should be called only after all scalar replaceable Allocate nodes
+  // have been scalar replaced. Therefore the nodes producing values for the
+  // fields accessed by users of the RAM have already been registered.
+  //
+  // The method will iterate over the users of 'ram' and replace the nodes
+  // that use the _value_ of field 'x' by a value Phi merging nodes that
+  // produce value for field 'x' in different control branches. Safepoints
+  // and traps are special since they require a reference to the
+  // 'ram' itself. For those cases we create an SafePointScalarObjectNode,
+  // similar to what is done to regular scalar replacement.
+  bool eliminate_reduced_allocation_merge(ReducedAllocationMergeNode *ram);
 
   void eliminate_gc_barrier(Node *p2x);
   void mark_eliminated_box(Node* box, Node* obj);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -293,6 +293,12 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
   ctl = in(MemNode::Control);
   // Don't bother trying to transform a dead node
   if (ctl && ctl->is_top())  return NodeSentinel;
+  Node *address = in(MemNode::Address);
+  // Don't try to optimize loads under RAM
+  if (address != NULL && address->is_AddP() && address->in(AddPNode::Base) != NULL &&
+      address->in(AddPNode::Base)->is_ReducedAllocationMerge()) {
+    return NodeSentinel;
+  }
 
   PhaseIterGVN *igvn = phase->is_IterGVN();
   // Wait if control on the worklist.
@@ -326,7 +332,6 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
     return NodeSentinel; // caller will return NULL
   }
 
-  Node *address = in(MemNode::Address);
   const Type *t_adr = phase->type(address);
   if (t_adr == Type::TOP)              return NodeSentinel; // caller will return NULL
 
@@ -862,7 +867,8 @@ bool LoadNode::is_immutable_value(Node* adr) {
 //----------------------------LoadNode::make-----------------------------------
 // Polymorphic factory method:
 Node* LoadNode::make(PhaseGVN& gvn, Node* ctl, Node* mem, Node* adr, const TypePtr* adr_type, const Type* rt, BasicType bt, MemOrd mo,
-                     ControlDependency control_dependency, bool require_atomic_access, bool unaligned, bool mismatched, bool unsafe, uint8_t barrier_data) {
+                     ControlDependency control_dependency, bool require_atomic_access, bool unaligned, bool mismatched, bool unsafe, uint8_t barrier_data,
+                     bool decode_narrow) {
   Compile* C = gvn.C;
 
   // sanity check the alias category against the created node type
@@ -914,7 +920,7 @@ Node* LoadNode::make(PhaseGVN& gvn, Node* ctl, Node* mem, Node* adr, const TypeP
     load->set_unsafe_access();
   }
   load->set_barrier_data(barrier_data);
-  if (load->Opcode() == Op_LoadN) {
+  if (load->Opcode() == Op_LoadN && decode_narrow) {
     Node* ld = gvn.transform(load);
     return new DecodeNNode(ld, ld->bottom_type()->make_ptr());
   }

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -230,7 +230,7 @@ public:
                     const TypePtr* at, const Type* rt, BasicType bt,
                     MemOrd mo, ControlDependency control_dependency = DependsOnlyOnTest,
                     bool require_atomic_access = false, bool unaligned = false, bool mismatched = false, bool unsafe = false,
-                    uint8_t barrier_data = 0);
+                    uint8_t barrier_data = 0, bool decode_narrow = true);
 
   virtual uint hash()   const;  // Check the type
 

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -152,6 +152,7 @@ class ProjNode;
 class RangeCheckNode;
 class RegMask;
 class RegionNode;
+class ReducedAllocationMergeNode;
 class RootNode;
 class SafePointNode;
 class SafePointScalarObjectNode;
@@ -707,6 +708,7 @@ public:
         DEFINE_CLASS_ID(EncodePKlass, EncodeNarrowPtr, 1)
       DEFINE_CLASS_ID(Vector, Type, 7)
         DEFINE_CLASS_ID(VectorMaskCmp, Vector, 0)
+      DEFINE_CLASS_ID(ReducedAllocationMerge,   Type, 8)
 
     DEFINE_CLASS_ID(Proj,  Node, 3)
       DEFINE_CLASS_ID(CatchProj, Proj, 0)
@@ -937,6 +939,7 @@ public:
   DEFINE_CLASS_QUERY(StoreVectorScatter)
   DEFINE_CLASS_QUERY(VectorMaskCmp)
   DEFINE_CLASS_QUERY(Unlock)
+  DEFINE_CLASS_QUERY(ReducedAllocationMerge)
 
   #undef DEFINE_CLASS_QUERY
 

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -822,7 +822,8 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
 
     ObjectValue* sv = sv_for_node_id(objs, spobj->_idx);
     if (sv == NULL) {
-      ciKlass* cik = t->is_oopptr()->klass();
+      ciKlass* cik = t->isa_instptr() != NULL ? t->isa_instptr()->instance_klass()
+                                              : t->is_oopptr()->klass();
       assert(cik->is_instance_klass() ||
              cik->is_array_klass(), "Not supported allocation.");
       ScopeValue* klass_sv = new ConstantOopWriteValue(cik->java_mirror()->constant_encoding());

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -37,6 +37,8 @@ enum CompilerPhaseType {
   PHASE_EXPAND_VBOX,
   PHASE_ELIMINATE_VBOX_ALLOC,
   PHASE_PHASEIDEAL_BEFORE_EA,
+  PHASE_BEFORE_REDUCE_ALLOCATION,
+  PHASE_AFTER_REDUCE_ALLOCATION,
   PHASE_ITER_GVN_AFTER_VECTOR,
   PHASE_ITER_GVN_BEFORE_EA,
   PHASE_ITER_GVN_AFTER_EA,
@@ -88,6 +90,8 @@ class CompilerPhaseTypeHelper {
       case PHASE_EXPAND_VBOX:                return "Expand VectorBox";
       case PHASE_ELIMINATE_VBOX_ALLOC:       return "Eliminate VectorBoxAllocate";
       case PHASE_PHASEIDEAL_BEFORE_EA:       return "PhaseIdealLoop before EA";
+      case PHASE_BEFORE_REDUCE_ALLOCATION:   return "Before reducing allocation merges";
+      case PHASE_AFTER_REDUCE_ALLOCATION:    return "After reducing allocation merges";
       case PHASE_ITER_GVN_AFTER_VECTOR:      return "Iter GVN after vector box elimination";
       case PHASE_ITER_GVN_BEFORE_EA:         return "Iter GVN before EA";
       case PHASE_ITER_GVN_AFTER_EA:          return "Iter GVN after EA";

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1143,6 +1143,14 @@ class TypeInstPtr : public TypeOopPtr {
 
   bool  is_loaded() const { return _klass->is_loaded(); }
 
+  // Instance klass, ignoring any interface
+  ciInstanceKlass* instance_klass() const {
+    if (klass()->is_loaded() && klass()->is_interface()) {
+      return Compile::current()->env()->Object_klass();
+    }
+    return klass()->as_instance_klass();
+  }
+
   // Make a pointer to a constant oop.
   static const TypeInstPtr *make(ciObject* o) {
     return make(TypePtr::Constant, o->klass(), true, o, 0, InstanceBot);

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -913,10 +913,14 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   c2_nonstatic_field(Compile,                  _regalloc,                                     PhaseRegAlloc*)                        \
   c2_nonstatic_field(Compile,                  _method,                                       ciMethod*)                             \
   c2_nonstatic_field(Compile,                  _compile_id,                                   const int)                             \
-  c2_nonstatic_field(Compile,                  _subsume_loads,                                const bool)                            \
-  c2_nonstatic_field(Compile,                  _do_escape_analysis,                           const bool)                            \
-  c2_nonstatic_field(Compile,                  _eliminate_boxing,                             const bool)                            \
+  c2_nonstatic_field(Compile,                  _options,                                      const Options)                         \
   c2_nonstatic_field(Compile,                  _ilt,                                          InlineTree*)                           \
+                                                                                                                                     \
+  c2_nonstatic_field(Options,                  _subsume_loads,                                const bool)                            \
+  c2_nonstatic_field(Options,                  _do_escape_analysis,                           const bool)                            \
+  c2_nonstatic_field(Options,                  _eliminate_boxing,                             const bool)                            \
+  c2_nonstatic_field(Options,                  _do_locks_coarsening,                          const bool)                            \
+  c2_nonstatic_field(Options,                  _install_code,                                 const bool)                            \
                                                                                                                                      \
   c2_nonstatic_field(InlineTree,               _caller_jvms,                                  JVMState*)                             \
   c2_nonstatic_field(InlineTree,               _method,                                       ciMethod*)                             \
@@ -1477,6 +1481,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
                                                                           \
   declare_c2_toplevel_type(Matcher)                                       \
   declare_c2_toplevel_type(Compile)                                       \
+  declare_c2_toplevel_type(Options)                                       \
   declare_c2_toplevel_type(InlineTree)                                    \
   declare_c2_toplevel_type(OptoRegPair)                                   \
   declare_c2_toplevel_type(JVMState)                                      \

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIterativeEA.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIterativeEA.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8276455
+ * @summary Test C2 iterative Escape Analysis to remove all allocations in test
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestIterativeEA
+ */
+public class TestIterativeEA {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    static class MyClass {
+        int val;
+        public MyClass(int val) {
+            this.val = val;
+        }
+    }
+
+    static class AbstractClass {
+        final int unused;
+        public AbstractClass() {
+            unused = 42;
+        }
+    }
+
+    static class HolderWithSuper extends AbstractClass {
+        final MyClass obj;
+        public HolderWithSuper(MyClass obj) {
+            this.obj = obj;
+        }
+    }
+
+    static class Holder {
+        final MyClass obj;
+        public Holder(MyClass obj) {
+            this.obj = obj;
+        }
+    }
+
+    static class GenericHolder {
+        final Object obj;
+        public GenericHolder(Object obj) {
+            this.obj = obj;
+        }
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    public static int testSlow(int val) {
+        MyClass obj = new MyClass(val);
+        HolderWithSuper h1 = new HolderWithSuper(obj);
+        GenericHolder h2 = new GenericHolder(h1);
+        return ((HolderWithSuper)h2.obj).obj.val;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    public static int testFast(int val) {
+        MyClass obj = new MyClass(val);
+        Holder h1 = new Holder(obj);
+        GenericHolder h2 = new GenericHolder(h1);
+        return ((Holder)h2.obj).obj.val;
+    }
+
+    static class A {
+        int i;
+        public A(int i) {
+            this.i = i;
+        }
+    }
+
+    static class B {
+        A a;
+        public B(A a) {
+            this.a = a;
+        }
+    }
+
+    static class C {
+        B b;
+        public C(B b) {
+            this.b = b;
+        }
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    static int testNested(int i) {
+        C c = new C(new B(new A(i)));
+        return c.b.a.i;
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
@@ -1,0 +1,935 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests.scalarReplacement;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8281429
+ * @summary Tests that C2 can correctly scalar replace some object allocation merges.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.scalarReplacement.AllocationMergesTests
+ */
+public class AllocationMergesTests {
+
+    private static Point global = new Point(2022, 2023);
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:+ReduceAllocationMerges",
+                                   "-XX:CompileCommand=exclude,*::dummy*");
+    }
+
+    // ------------------ No Scalar Replacement Should Happen in The Tests Below ------------------- //
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "1" })
+    int testGlobalEscape(int x, int y) {
+        Point p = new Point(x, y);
+
+        AllocationMergesTests.global_escape = p;
+
+        return p.x * p.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "1" })
+    int testArgEscape(int x, int y) {
+        Point p = new Point(x, y);
+
+        int val = dummy(p);
+
+        return val + p.x + p.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    int testEscapeInCallAfterMerge(boolean cond, boolean cond2, int x, int y) {
+        Point p = new Point(x, x);
+
+        if (cond)
+            p = new Point(y, y);
+
+        if (cond2) {
+            dummy(p);
+        }
+
+        return p.x * p.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Merge won't be reduced because write to field inside the loop
+    int testNoEscapeWithWriteInLoop(boolean cond, boolean cond2, int x, int y) {
+        Point p = new Point(x, y);
+        int res = 0;
+
+        if (cond)
+            p = new Point(y, x);
+
+        for (int i=0; i<100; i++) {
+            p.x += p.y + i;
+            p.y += p.x + i;
+        }
+
+        return res + p.x + p.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Merge won't be reduced because write to field inside the loop
+    int testPollutedWithWrite(boolean cond, int l) {
+        Shape obj1 = new Square(l);
+        Shape obj2 = new Square(l);
+        Shape obj = null;
+
+        if (cond)
+            obj = obj1;
+        else
+            obj = obj2;
+
+        for (int i = 1; i < 132; i++) {
+            obj.x++;
+        }
+
+        return obj1.x + obj2.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Merge won't be reduced because objects have different types
+    int testPollutedPolymorphic(boolean cond, int l) {
+        Shape obj1 = new Square(l);
+        Shape obj2 = new Circle(l);
+        Shape obj = (cond ? obj1 : obj2);
+        int res = 0;
+
+        for (int i = 1; i < 232; i++) {
+            res += obj.x;
+        }
+
+        return res + obj1.x + obj2.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Merge won't be reduced because write to one of the inputs *after* the merge
+    int testMergedLoadAfterDirectStore(boolean cond, int x, int y) {
+        Point p0 = new Point(x, x);
+        Point p1 = new Point(y, y);
+        Point p = null;
+
+        if (cond)
+            p = p0;
+        else
+            p = p1;
+
+        p0.x = x * y;
+
+        return p.x;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "3" })
+    // p2 is ArgEscape
+    // p is written inside the loop.
+    int testMergedAccessAfterCallWithWrite(boolean cond, int x, int y) {
+        Point p2 = new Point(x, x);
+        Point p = new Point(y, y);
+
+        p.x = p.x * y;
+
+        if (cond)
+            p = new Point(x, x);
+
+        dummy(p2);
+
+        for (int i=3; i<324; i++)
+            p.x += i * x;
+
+        return p.x;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Allocations will be NSR because they are used in a CallStaticJava
+    int testLoadAfterTrap(boolean cond, int x, int y) {
+        Point p = null;
+
+        if (cond)
+            p = new Point(x, x);
+        else
+            p = new Point(y, y);
+
+        dummy(x+y);
+
+        return p.x + p.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "1" })
+    // The merge won't be simplified because the merge with NULL instead of Allocate
+    int testCondAfterMergeWithNull(boolean cond1, boolean cond2, int x, int y) {
+        Point p = null;
+
+        if (cond1)
+            p = new Point(y, x);
+
+        if (cond2 && cond1) {
+            return p.x;
+        }
+        else {
+            return 321;
+        }
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // A loop is appearing between the Phis in this method and is preventing the reduction
+    int testLoadAfterLoopAlias(boolean cond, int x, int y) {
+        Point a = new Point(x, y);
+        Point b = new Point(y, x);
+        Point c = a;
+
+        for (int i=10; i<832; i++) {
+            if (i == 500) {
+                c = b;
+            }
+        }
+
+        return cond ? c.x : c.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "1" })
+    // Merge won't be reduced because one of the inputs come from a call
+    int testCallOneSide(boolean cond1, int x, int y) {
+        Point p = dummy(x, y);
+
+        if (cond1)
+            p = new Point(y, x);
+
+        return p.x;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.CALL, "3" })
+    // Merge won't be reduced because both of the inputs come from a call
+    // The additional "Call" node is because of the uncommon_trap for checking if
+    // "p" is null
+    int testCallTwoSide(boolean cond1, int x, int y) {
+        Point p = dummy(x, y);
+
+        if (cond1)
+            p = dummy(y, x);
+
+        return p.x;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "3" })
+    // "p" won't be reduced because it's touched by Call to dummy
+    int testMergedAccessAfterCallNoWrite(boolean cond, int x, int y) {
+        Point p2 = new Point(x, x);
+        Point p = new Point(y, y);
+        int res = 0;
+
+        p.x = p.x * y;
+
+        if (cond)
+            p = new Point(y, y);
+
+        dummy(p2);
+
+        for (int i=3; i<324; i++)
+            res += p.x + i * x;
+
+        return res;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "1" })
+    int testCmpMergeWithNull_Second(boolean cond, int x, int y) {
+        Point p = null;
+
+        if (cond)
+            p = new Point(x*x, y*y);
+
+        dummy(x);
+
+        if (p != null)
+            return p.x * p.y;
+        else
+            return 1984;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "1" })
+    int testObjectIdentity(boolean cond, int x, int y) {
+        Point o = new Point(x, y);
+
+        if (cond) {
+            o = global;
+            dummy();
+        }
+
+        dummy();
+
+        return o == global ? o.x + o.y : 0;
+    }
+
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // The merge won't be reduced because there is a SafePoint/Call referring to the merge
+    int testSubclassesTrapping(boolean c1, boolean c2, int x, int y, int w, int z) {
+        new A();
+        Root s = new Home(x, y);
+        new B();
+
+        if (c1) {
+            new C();
+            s = new Etc("Hello");
+            new D();
+        }
+        else {
+            new E();
+            s = new Usr(y, x, z);
+            new F();
+        }
+
+        dummy();
+
+        return s.a;
+    }
+
+    // ------------------ Some Objects Will be Scalar Replaced in These Tests ------------------- //
+
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    // Since there is no Call/SafePoint after the merge we can reduce the allocation
+    int testSubclasses(boolean c1, boolean c2, int x, int y, int w, int z) {
+        new A();
+        Root s = new Home(x, y);
+        new B();
+
+        if (c1) {
+            new C();
+            s = new Etc("Hello");
+            new D();
+        }
+        else {
+            new E();
+            s = new Usr(y, x, z);
+            new F();
+        }
+
+        new G();
+
+        return s.a;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "2" })
+    Point testNestedObjectsObject(boolean cond, int x, int y) {
+        Picture p = new Picture(x, x, y);
+
+        if (cond)
+            p = new Picture(y, y, x);
+
+        return p.position;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC_ARRAY, "2" })
+    Point[] testNestedObjectsArray(boolean cond, int x, int y) {
+        PicturePositions p = new PicturePositions(x, y, x+y);
+
+        if (cond)
+            p = new PicturePositions(x+1, y+1, x+y+1);
+
+        return p.positions;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    // The merge for "p" will be removed during iterative EA; after the allocation
+    // inside the last if is removed in a previous EA iteration.
+    int testTrappingAfterMerge(boolean cond, int x, int y) {
+        Point p = new Point(x, y);
+        int res = 0;
+
+        if (cond)
+            p = new Point(y, y);
+
+        for (int i=832; i<932; i++) {
+            res += p.x;
+        }
+
+        if (x > y) {
+            res += new Point(p.x, p.y).x;
+        }
+
+        return res;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = {IRNode.ALLOC})
+    int simpleMerge(boolean cond, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond)
+            p = new Point(y, x);
+
+        return p.x * p.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testSimpleAliasedAlloc(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(y, x);
+        Point p = p1;
+
+        if (cond)
+            p = p2;
+
+        return p.x * p.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testSimpleDoubleMerge(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+1, y+1);
+
+        if (cond) {
+            p1 = new Point(y, x);
+            p2 = new Point(y+1, x+1);
+        }
+
+        return p1.x + p2.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "1" })
+    // "p2" is scalar replaced because it's not used in "dummy" except as debug info
+    int testSimpleMixedEscape(int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+1, y+1);
+
+        int val = dummy(p1);
+
+        return val + p1.x + p2.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    // Object p is scalar replaced because the "p = dummy(...)" calls
+    // are actually converted to traps and therefore there is no merge phi
+    int testMultiwayMerge(int x, int y) {
+        Point p = new Point(0, 0);
+
+        if (x == y) {
+            p = dummy(x, x);
+        }
+        else if (dummy(x) == 1) {
+            p = dummy(x, y);
+        }
+        else if (dummy(y) == 1) {
+            p = dummy(y, x);
+        }
+
+        return p.x;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testConsecutiveSimpleMerge(boolean cond1, boolean cond2, int x, int y) {
+        Point p0 = new Point(x, x);
+        Point p1 = new Point(x, y);
+        Point pA = null;
+
+        Point p2 = new Point(y, x);
+        Point p3 = new Point(y, y);
+        Point pB = null;
+
+        if (cond1)
+            pA = p0;
+        else
+            pA = p1;
+
+        if (cond2)
+            pB = p2;
+        else
+            pB = p3;
+
+        return pA.x * pA.y + pB.x * pB.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testDoubleIfElseMerge(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+1, y+1);
+
+        if (cond) {
+            p1 = new Point(y, x);
+            p2 = new Point(y, x);
+        }
+        else {
+            p1 = new Point(x, y);
+            p2 = new Point(x+1, y+1);
+        }
+
+        return p1.x * p2.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testNoEscapeWithLoadInLoop(boolean cond, int x, int y) {
+        Point p = new Point(x, y);
+        int res = 0;
+
+        if (cond)
+            p = new Point(y, x);
+
+        for (int i=3342; i<4234; i++) {
+            res += p.x + p.y + i;
+        }
+
+        return res + p.x + p.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testCmpAfterMerge(boolean cond, boolean cond2, int x, int y) {
+        Point a = new Point(x, y);
+        Point b = new Point(y, x);
+        Point c = null;
+
+        if (x+2 >= y-5)
+            c = a;
+        else
+            c = b;
+
+        return cond2 ? c.x : c.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testCmpMergeWithNull(boolean cond, int x, int y) {
+        Point p = null;
+
+        if (cond)
+            p = new Point(x*x, y*y);
+        else if (x == y)
+            p = new Point(x+y, x*y);
+
+        if (p != null)
+            return p.x * p.y;
+        else
+            return 1984;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testCondAfterMergeWithAllocate(boolean cond1, boolean cond2, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond1)
+            p = new Point(y, x);
+
+        if (cond2 && cond1) {
+            return p.x;
+        }
+        else {
+            return 321;
+        }
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testCondLoadAfterMerge(boolean cond1, boolean cond2, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond1)
+            p = new Point(y, x);
+
+        if (cond1 == false && cond2 == false)
+            return p.x + 1;
+        else if (cond1 == false && cond2 == true)
+            return p.x + 30;
+        else if (cond1 == true && cond2 == false)
+            return p.x + 40;
+        else if (cond1 == true && cond2 == true)
+            return p.x + 50;
+        else
+            return -1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    int testIfElseInLoop() {
+        int res = 0;
+
+        for (int i = 1; i < 1000; i++) {
+            Point obj = new Point(i, i);
+
+            if (i % 2 == 1)
+                obj = new Point(i, i+1);
+            else
+                obj = new Point(i-1, i);
+
+            res += obj.x;
+        }
+
+        return res;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testLoadInCondAfterMerge(boolean cond, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond)
+            p = new Point(y, x);
+
+        if (p.x == 10) {
+            if (p.y == 10) {
+                return dummy(10);
+            }
+            else {
+                return dummy(20);
+            }
+        }
+        else if (p.x == 20) {
+            if (p.y == 20) {
+                return dummy(30);
+            }
+            else {
+                return dummy(40);
+            }
+        }
+
+        return 1984;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testLoadInLoop(boolean cond, int x, int y) {
+        Point obj1 = new Point(x, y);
+        Point obj2 = new Point(y, x);
+        Point obj = null;
+        int res = 0;
+
+        if (cond)
+            obj = obj1;
+        else
+            obj = obj2;
+
+        for (int i = 0; i < 532; i++) {
+            res += obj.x;
+        }
+
+        return res;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(counts = { IRNode.ALLOC, "1" })
+    // p2 is ArgEscape
+    // p1 can be scalar replaced
+    int testMergesAndMixedEscape(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x, y);
+        int val  = 0;
+
+        if (cond) {
+            p1 = new Point(x+1, y+1);
+            val = dummy(p2);
+        }
+
+        return val + p1.x + p2.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testPartialPhis(boolean cond, int l, int x, int y) {
+        int k = l;
+
+        if (l == 0) {
+            k = l + 1;
+        }
+        else if (l == 2) {
+            k = l + 2;
+        }
+        else if (l == 3) {
+            new Point(x, y);
+        }
+        else if (l == 4) {
+            new Point(y, x);
+        }
+
+        return k;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testPollutedNoWrite(boolean cond, int l) {
+        Shape obj1 = new Square(l);
+        Shape obj2 = new Square(l);
+        Shape obj = null;
+        int res = 0;
+
+        if (cond)
+            obj = obj1;
+        else
+            obj = obj2;
+
+        for (int i = 1; i < 132; i++) {
+            res += obj.x;
+        }
+
+        return res + obj1.x + obj2.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testThreeWayAliasedAlloc(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+1, y+1);
+        Point p3 = new Point(x+2, y+2);
+
+        if (cond)
+            p3 = p1;
+        else
+            p3 = p2;
+
+        return p3.x + p3.y;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int TestTrapAfterMerge(boolean cond, int x, int y) {
+        Point p = new Point(x, x);
+
+        if (cond)
+            p = new Point(y, y);
+
+        for (int i=402; i<432; i+=x) {
+            x++;
+        }
+
+        return p.x + x;
+    }
+
+    @Test
+    @Arguments({ Argument.RANDOM_EACH, Argument.RANDOM_EACH })
+    @IR(failOn = { IRNode.ALLOC })
+    int testMergedWithDeadCode(boolean cond, int x) {
+        ADefaults obj1 = new ADefaults(x);
+        ADefaults obj2 = new ADefaults();
+        ADefaults obj = cond ? obj1 : obj2;
+
+        return obj1.i + obj.ble + 1082;
+    }
+
+
+    // ------------------ Utility for Testing ------------------- //
+
+    @DontCompile
+    static int dummy(Point p) {
+        return p.x * p.y;
+    }
+
+    @DontCompile
+    static int dummy(int x) {
+        return x;
+    }
+
+    @DontCompile
+    static Point dummy(int x, int y) {
+        return new Point(x, y);
+    }
+
+    @DontCompile
+    static ADefaults dummy_defaults() {
+        return new ADefaults();
+    }
+
+    private static Point global_escape;
+
+    static class Point {
+        int x, y;
+        Point(int x, int y) { this.x = x; this.y = y; }
+    }
+
+    class Shape {
+        int x, y, l;
+        Shape(int x, int y) { this.x = x; this.y = y; }
+    }
+
+    class Square extends Shape {
+        Square(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    class Circle extends Shape {
+        Circle(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+   static class ADefaults {
+        static int ble;
+        int i;
+        ADefaults(int i) { this.i = i; }
+        ADefaults() { }
+    }
+
+    static class Picture {
+        public int id;
+        public Point position;
+
+        public Picture(int id, int x, int y) {
+            this.id = id;
+            this.position = new Point(x, y);
+        }
+    }
+
+    static class PicturePositions {
+        public int id;
+        public Point[] positions;
+
+        public PicturePositions(int id, int x, int y) {
+            this.id = id;
+            this.positions = new Point[] { new Point(x, y), new Point(y, x) };
+        }
+    }
+
+    class Root {
+        public int a;
+        public int b;
+        public int c;
+        public int d;
+        public int e;
+
+        public Root(int a, int b, int c, int d, int e) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+            this.e = e;
+        }
+    }
+
+    class Usr extends Root {
+        public float flt;
+
+        public Usr(float a, float b, float c) {
+            super((int)a, (int)b, (int)c, 0, 0);
+            this.flt = a;
+        }
+    }
+
+    class Home extends Root {
+        public double[] arr;
+
+        public Home(double a, double b) {
+            super((int)a, (int)b, 0, 0, 0);
+            this.arr = new double[] {a, b};
+        }
+
+    }
+
+    class Tmp extends Root {
+        public String s;
+
+        public Tmp(String s) {
+            super((int)s.length(), 0, 0, 0, 0);
+            this.s = s;
+        }
+    }
+
+    class Etc extends Root {
+        public String a;
+
+        public Etc(String s) {
+            super((int)s.length(), 0, 0, 0, 0);
+            this.a = s;
+        }
+    }
+
+    class A { }
+    class B { }
+    class C { }
+    class D { }
+    class E { }
+    class F { }
+    class G { }
+}
+

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests.scalarReplacement;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8267265
+ * @summary Tests that Escape Analysis and Scalar Replacement is able to handle some simple cases.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.scalarReplacement.ScalarReplacementTests
+ */
+public class ScalarReplacementTests {
+    private class Person {
+        private String name;
+        private int age;
+
+        public Person(Person p) {
+            this.name = p.getName();
+            this.age = p.getAge();
+        }
+
+        public Person(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() { return name; }
+        public int getAge() { return age; }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @Arguments(Argument.RANDOM_EACH)
+    @IR(failOn = {IRNode.CALL, IRNode.LOAD, IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.ALLOC})
+    public String stringConstant(int age) {
+        Person p = new Person("Java", age);
+        return p.getName();
+    }
+
+    @Test
+    @Arguments(Argument.RANDOM_EACH)
+    @IR(failOn = {IRNode.CALL, IRNode.LOAD, IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.ALLOC})
+    public int intConstant(int age) {
+        Person p = new Person("Java", age);
+        return p.getAge();
+    }
+
+    @Test
+    @Arguments(Argument.RANDOM_EACH)
+    @IR(failOn = {IRNode.CALL, IRNode.LOAD, IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.ALLOC})
+    public String nestedStringConstant(int age) {
+        Person p1 = new Person("Java", age);
+        Person p2 = new Person(p1);
+        return p2.getName();
+    }
+
+    @Test
+    @Arguments(Argument.RANDOM_EACH)
+    @IR(failOn = {IRNode.CALL, IRNode.LOAD, IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.ALLOC})
+    public int nestedIntConstant(int age) {
+        Person p1 = new Person("Java", age);
+        Person p2 = new Person(p1);
+        return p2.getAge();
+    }
+
+    @Test
+    @Arguments({Argument.RANDOM_EACH, Argument.RANDOM_EACH})
+    @IR(failOn = {IRNode.CALL, IRNode.LOAD, IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.ALLOC})
+    public int nestedConstants(int age1, int age2) {
+        Person p = new Person(
+                        new Person("Java", age1).getName(),
+                        new Person("Java", age2).getAge());
+        return p.getAge();
+    }
+}

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestIterativeEA.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestIterativeEA.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8276455
+ * @summary Test C2 iterative Escape Analysis
+ * @library /test/lib /
+ *
+ * @requires vm.flagless
+ * @requires vm.compiler2.enabled & vm.debug == true
+ *
+ * @run driver TestIterativeEA
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestIterativeEA {
+
+  public static void main(String[] args) throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-server", "-XX:-TieredCompilation", "-Xbatch", "-XX:+PrintEliminateAllocations",
+                 Launcher.class.getName());
+
+    OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+    System.out.println(analyzer.getOutput());
+
+    analyzer.shouldHaveExitValue(0);
+    analyzer.shouldContain("++++ Eliminated: 26 Allocate");
+    analyzer.shouldContain("++++ Eliminated: 48 Allocate");
+    analyzer.shouldContain("++++ Eliminated: 78 Allocate");
+  }
+
+  static class A {
+    int i;
+
+    public A(int i) {
+      this.i = i;
+    }
+  }
+
+  static class B {
+    A a;
+
+    public B(A a) {
+      this.a = a;
+    }
+  }
+
+  static class C {
+    B b;
+
+    public C(B b) {
+      this.b = b;
+    }
+  }
+
+  static int test(int i) {
+    C c = new C(new B(new A(i)));
+    return c.b.a.i;
+  }
+
+  static class Launcher {
+    public static void main(String[] args) {
+      for (int i = 0; i < 12000; ++i) {
+        int j = test(i);
+      }
+    }
+  }
+
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/IterativeEA.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/IterativeEA.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+
+public class IterativeEA {
+
+    public static int ii = 1;
+
+    static class A {
+        int i;
+
+        public A(int i) {
+            this.i = i;
+        }
+    }
+
+    static class B {
+        A a;
+
+        public B(A a) {
+            this.a = a;
+        }
+    }
+
+    static class C {
+        B b;
+
+        public C(B b) {
+            this.b = b;
+        }
+    }
+
+    @Benchmark
+    public int test1() {
+        C c = new C(new B(new A(ii)));
+        return c.b.a.i;
+    }
+
+    static class Point {
+        int x;
+        int y;
+        int ax[];
+        int ay[];
+    }
+
+    @Benchmark
+    public int test2() {
+        Point p = new Point();
+        p.ax = new int[2];
+        p.ay = new int[2];
+        int x = 3;
+        p.ax[0] = x;
+        p.ay[1] = 3 * x + ii;
+        return p.ax[0] * p.ay[1];
+    }
+
+    public static final Double dbc = Double.valueOf(1.);
+
+    @Benchmark
+    public double test3() {
+        Double j1 = Double.valueOf(1.);
+        Double j2 = Double.valueOf(1.);
+        for (int i = 0; i< 1000; i++) {
+            j1 = j1 + 1.;
+            j2 = j2 + 2.;
+        }
+        return j1 + j2;
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/PointerBenchmarkFlat.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/PointerBenchmarkFlat.java
@@ -1,0 +1,164 @@
+/*
+  * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU General Public License version 2 only, as
+  * published by the Free Software Foundation.
+  *
+  * This code is distributed in the hope that it will be useful, but WITHOUT
+  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+  * version 2 for more details (a copy is included in the LICENSE file that
+  * accompanied this code).
+  *
+  * You should have received a copy of the GNU General Public License version
+  * 2 along with this work; if not, write to the Free Software Foundation,
+  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+  *
+  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+  * or visit www.oracle.com if you need additional information or have any
+  * questions.
+  */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 3)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class PointerBenchmarkFlat {
+
+    static final int ELEM_SIZE = 1_000_000;
+
+    PointerImpl ptr_ptr;
+    PointerImplFlat ptr_ptr_flat;
+
+    @Setup
+    public void setup() {
+        ptr_ptr = new PointerImpl(new FakeSegment(MemoryAddress.NULL, Long.MAX_VALUE));
+        ptr_ptr_flat = new PointerImplFlat(new FakeSegmentFlat(MemoryAddress.NULL, Long.MAX_VALUE));
+    }
+
+    static class MemoryAddress {
+        private long addr;
+
+        public MemoryAddress(long addr) {
+            this.addr = addr;
+        }
+
+        long toRawLongValue() {
+            return addr;
+        }
+
+        private static final MemoryAddress NULL = new MemoryAddress(0);
+
+        static MemoryAddress ofLong(long val) {
+            return new MemoryAddress(val);
+        }
+    }
+
+    static class PointerImpl {
+        final FakeSegment segment;
+
+        public PointerImpl(FakeSegment segment) {
+            this.segment = segment;
+        }
+
+        MemoryAddress address() {
+            return segment.address();
+        }
+
+        PointerImpl get(long index) {
+            MemoryAddress address = MemoryAddress.ofLong(index);
+            FakeSegment holder = new FakeSegment(address, Long.MAX_VALUE);
+            return new PointerImpl(holder);
+        }
+    }
+
+    static class PointerImplFlat {
+        final FakeSegmentFlat segment;
+
+        public PointerImplFlat(FakeSegmentFlat segment) {
+            this.segment = segment;
+        }
+
+        MemoryAddress address() {
+            return segment.address();
+        }
+
+        PointerImplFlat get(long index) {
+            MemoryAddress address = MemoryAddress.ofLong(index);
+            FakeSegmentFlat holder = new FakeSegmentFlat(address, Long.MAX_VALUE);
+            return new PointerImplFlat(holder);
+        }
+    }
+
+    static class AbstractFakeSegment {
+        final long size;
+
+        public AbstractFakeSegment(long size) {
+            this.size = size;
+        }
+    }
+
+    static class FakeSegment extends AbstractFakeSegment {
+        final MemoryAddress address;
+
+        public FakeSegment(MemoryAddress address, long size) {
+            super(size);
+            this.address = address;
+        }
+
+        MemoryAddress address() {
+            return address;
+        }
+    }
+
+    static class FakeSegmentFlat {
+        final MemoryAddress address;
+        final long size;
+
+        public FakeSegmentFlat(MemoryAddress address, long size) {
+            this.size = size;
+            this.address = address;
+        }
+
+        MemoryAddress address() {
+            return address;
+        }
+    }
+
+    @Benchmark
+    public long test() {
+        long sum = 0;
+        for (int i = 0 ; i < ELEM_SIZE ; i++) {
+            sum += ptr_ptr.get(i).address().toRawLongValue();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long testFlat() {
+        long sum = 0;
+        for (int i = 0 ; i < ELEM_SIZE ; i++) {
+            sum += ptr_ptr_flat.get(i).address().toRawLongValue();
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
This PR is to backport changes made in original PR https://github.com/openjdk/jdk/pull/9073  to JDK17 servicing branch 

    1. Identify Phi nodes that merge object allocations and replace them with a new IR node called ReducedAllocationMergeNode (RAM node).
    2. Scalar Replace the incoming allocations to the RAM node.
    3. Scalar Replace the RAM node itself.

There are a few conditions for doing the replacement of the Phi by a RAM node though - Although I plan to work on removing them in subsequent PRs:

    -The only supported users of the original Phi are AddP->Load, SafePoints/Traps, DecodeN.

These are the critical parts of the implementation and I'd appreciate it very much if you could tell me if what I implemented isn't violating any C2 IR constraints:

   - The way I identify/use the memory edges that will be used to find the last stored values to the merged object fields.
   - The way I check if there is an incoming Allocate node to the original Phi node.
   - The way I check if there is no store to the merged objects after they are merged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u pull/356/head:pull/356` \
`$ git checkout pull/356`

Update a local copy of the PR: \
`$ git checkout pull/356` \
`$ git pull https://git.openjdk.org/jdk17u pull/356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 356`

View PR using the GUI difftool: \
`$ git pr show -t 356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/356.diff">https://git.openjdk.org/jdk17u/pull/356.diff</a>

</details>
