### PR TITLE
8288302: Shenandoah: SIGSEGV in vm maybe related to jit compiling xerces

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -1080,7 +1080,8 @@ Node* ShenandoahBarrierSetC2::ideal_node(PhaseGVN* phase, Node* n, bool can_resh
   } else if (can_reshape &&
              n->Opcode() == Op_If &&
              ShenandoahBarrierC2Support::is_heap_stable_test(n) &&
-             n->in(0) != NULL) {
+             n->in(0) != NULL &&
+             n->outcnt() == 2) {
     Node* dom = n->in(0);
     Node* prev_dom = n;
     int op = n->Opcode();


### PR DESCRIPTION
This is a clean backport. This failure was reported by users on jdk 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288302](https://bugs.openjdk.org/browse/JDK-8288302): Shenandoah: SIGSEGV in vm maybe related to jit compiling xerces


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u pull/357/head:pull/357` \
`$ git checkout pull/357`

Update a local copy of the PR: \
`$ git checkout pull/357` \
`$ git pull https://git.openjdk.org/jdk17u pull/357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 357`

View PR using the GUI difftool: \
`$ git pr show -t 357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/357.diff">https://git.openjdk.org/jdk17u/pull/357.diff</a>

</details>
