### PR TITLE
8293010: JDI ObjectReference/referringObjects/referringObjects001 fails: assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) failed: checking

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1494,7 +1494,9 @@ void JvmtiExport::post_thread_end(JavaThread *thread) {
 
 void JvmtiExport::post_object_free(JvmtiEnv* env, GrowableArray<jlong>* objects) {
   assert(objects != NULL, "Nothing to post");
-  assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE), "checking");
+  if (!env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) {
+    return; // the event type has been already disabled
+  }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_OBJECT_FREE, ("[?] Trg Object Free triggered" ));
   EVT_TRACE(JVMTI_EVENT_OBJECT_FREE, ("[?] Evt Object Free sent"));


### PR DESCRIPTION
This is a follow up to JDK-8291456 and  JDK-8256811 which were backported to 17.0.6.

I had to resolve this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293010](https://bugs.openjdk.org/browse/JDK-8293010): JDI ObjectReference/referringObjects/referringObjects001 fails: assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) failed: checking


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u pull/364/head:pull/364` \
`$ git checkout pull/364`

Update a local copy of the PR: \
`$ git checkout pull/364` \
`$ git pull https://git.openjdk.org/jdk17u pull/364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 364`

View PR using the GUI difftool: \
`$ git pr show -t 364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/364.diff">https://git.openjdk.org/jdk17u/pull/364.diff</a>

</details>
