### PR TITLE
8304871: Use default visibility for static library builds

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -641,7 +641,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   STATIC_LIBS_CFLAGS="-DSTATIC_BUILD=1"
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     STATIC_LIBS_CFLAGS="$STATIC_LIBS_CFLAGS -ffunction-sections -fdata-sections \
-      -DJNIEXPORT='__attribute__((visibility(\"hidden\")))'"
+      -DJNIEXPORT='__attribute__((visibility(\"default\")))'"
   else
     STATIC_LIBS_CFLAGS="$STATIC_LIBS_CFLAGS -DJNIEXPORT="
   fi


### PR DESCRIPTION
Clean, very low risk backport that I'd like to get into OpenJDK `17.0.7` as a critical fix. It's a build change that only affects the static library build (unusual config). Thus, it is a no-op on the regular OpenJDK build with shared libs.

Testing:
- [x] Using the manual reproducer from https://github.com/graalvm/mandrel/issues/487 with a mandrel build using a patched JDK 17. Works with the patch, is broken without it.
- [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304871](https://bugs.openjdk.org/browse/JDK-8304871): Use default visibility for static library builds


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/367/head:pull/367` \
`$ git checkout pull/367`

Update a local copy of the PR: \
`$ git checkout pull/367` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 367`

View PR using the GUI difftool: \
`$ git pr show -t 367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/367.diff">https://git.openjdk.org/jdk17u/pull/367.diff</a>

</details>
