### PR TITLE
Read length of SNIServerName as unsigned.

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -408,7 +408,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         } else {
             requestedServerNames = new ArrayList<>();
             while (len > 0) {
-                int l = buf.get();
+                int l = Byte.toUnsignedInt(buf.get());
                 b = new byte[l];
                 buf.get(b, 0, l);
                 requestedServerNames.add(new SNIHostName(new String(b)));


### PR DESCRIPTION
The RFC allows Server Names to have up to 255 characters. The current code fails for names with length > 127. See https://www.rfc-editor.org/rfc/rfc6066#section-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/369/head:pull/369` \
`$ git checkout pull/369`

Update a local copy of the PR: \
`$ git checkout pull/369` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 369`

View PR using the GUI difftool: \
`$ git pr show -t 369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/369.diff">https://git.openjdk.org/jdk17u/pull/369.diff</a>

</details>
