### PR TITLE
Backport ac41c030030c3d31815474c793ac9c420c47e22c

### DIFF
--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -381,6 +381,35 @@ errOut:
 
 #define ADDNULL(list) (*env)->CallBooleanMethod(env, list, jm_listAdd, NULL)
 
+
+static void addTrustSettingsToInputTrust(JNIEnv *env, jmethodID jm_listAdd, CFArrayRef trustSettings, jobject inputTrust)
+{
+    CFIndex count = CFArrayGetCount(trustSettings);
+    for (int i = 0; i < count; i++) {
+        CFDictionaryRef oneTrust = (CFDictionaryRef) CFArrayGetValueAtIndex(trustSettings, i);
+        CFIndex size = CFDictionaryGetCount(oneTrust);
+        const void * keys [size];
+        const void * values [size];
+        CFDictionaryGetKeysAndValues(oneTrust, keys, values);
+        for (int j = 0; j < size; j++) {
+            NSString* s = [NSString stringWithFormat:@"%@", keys[j]];
+            ADD(inputTrust, s);
+            s = [NSString stringWithFormat:@"%@", values[j]];
+            ADD(inputTrust, s);
+        }
+        SecPolicyRef certPolicy;
+        certPolicy = (SecPolicyRef)CFDictionaryGetValue(oneTrust, kSecTrustSettingsPolicy);
+        if (certPolicy != NULL) {
+            CFDictionaryRef policyDict = SecPolicyCopyProperties(certPolicy);
+            ADD(inputTrust, @"SecPolicyOid");
+            NSString* s = [NSString stringWithFormat:@"%@", CFDictionaryGetValue(policyDict, @"SecPolicyOid")];
+            ADD(inputTrust, s);
+            CFRelease(policyDict);
+        }
+        ADDNULL(inputTrust);
+    }
+}
+
 static void addCertificatesToKeystore(JNIEnv *env, jobject keyStore)
 {
     // Search the user keychain list for all X509 certificates.
@@ -435,46 +464,40 @@ static void addCertificatesToKeystore(JNIEnv *env, jobject keyStore)
                 goto errOut;
             }
 
-            // Only add certificates with trusted settings
-            CFArrayRef trustSettings;
-            if (SecTrustSettingsCopyTrustSettings(certRef, kSecTrustSettingsDomainUser, &trustSettings)
-                    == errSecItemNotFound) {
+            // See KeychainStore::createTrustedCertEntry for content of inputTrust
+            // We load trust settings from domains kSecTrustSettingsDomainUser and kSecTrustSettingsDomainAdmin
+            // kSecTrustSettingsDomainSystem is ignored because it seems to only contain data for root certificates
+            jobject inputTrust = NULL;
+            CFArrayRef trustSettings = NULL;
+
+            // Load user trustSettings into inputTrust
+            if (SecTrustSettingsCopyTrustSettings(certRef, kSecTrustSettingsDomainUser, &trustSettings) == errSecSuccess && trustSettings != NULL) {
+                inputTrust = (*env)->NewObject(env, jc_arrayListClass, jm_arrayListCons);
+                if (inputTrust == NULL) {
+                    CFRelease(trustSettings);
+                    goto errOut;
+                }
+                addTrustSettingsToInputTrust(env, jm_listAdd, trustSettings, inputTrust);
+                CFRelease(trustSettings);
+            }
+            // Load admin trustSettings into inputTrust
+            trustSettings = NULL;
+            if (SecTrustSettingsCopyTrustSettings(certRef, kSecTrustSettingsDomainAdmin, &trustSettings) == errSecSuccess && trustSettings != NULL) {
+                if (inputTrust == NULL) {
+                    inputTrust = (*env)->NewObject(env, jc_arrayListClass, jm_arrayListCons);
+                }
+                if (inputTrust == NULL) {
+                    CFRelease(trustSettings);
+                    goto errOut;
+                }
+                addTrustSettingsToInputTrust(env, jm_listAdd, trustSettings, inputTrust);
+                CFRelease(trustSettings);
+            }
+
+            // Only add certificates with trust settings
+            if (inputTrust == NULL) {
                 continue;
             }
-
-            // See KeychainStore::createTrustedCertEntry for content of inputTrust
-            jobject inputTrust = (*env)->NewObject(env, jc_arrayListClass, jm_arrayListCons);
-            if (inputTrust == NULL) {
-                CFRelease(trustSettings);
-                goto errOut;
-            }
-
-            // Dump everything inside trustSettings into inputTrust
-            CFIndex count = CFArrayGetCount(trustSettings);
-            for (int i = 0; i < count; i++) {
-                CFDictionaryRef oneTrust = (CFDictionaryRef) CFArrayGetValueAtIndex(trustSettings, i);
-                CFIndex size = CFDictionaryGetCount(oneTrust);
-                const void * keys [size];
-                const void * values [size];
-                CFDictionaryGetKeysAndValues(oneTrust, keys, values);
-                for (int j = 0; j < size; j++) {
-                    NSString* s = [NSString stringWithFormat:@"%@", keys[j]];
-                    ADD(inputTrust, s);
-                    s = [NSString stringWithFormat:@"%@", values[j]];
-                    ADD(inputTrust, s);
-                }
-                SecPolicyRef certPolicy;
-                certPolicy = (SecPolicyRef)CFDictionaryGetValue(oneTrust, kSecTrustSettingsPolicy);
-                if (certPolicy != NULL) {
-                    CFDictionaryRef policyDict = SecPolicyCopyProperties(certPolicy);
-                    ADD(inputTrust, @"SecPolicyOid");
-                    NSString* s = [NSString stringWithFormat:@"%@", CFDictionaryGetValue(policyDict, @"SecPolicyOid")];
-                    ADD(inputTrust, s);
-                    CFRelease(policyDict);
-                }
-                ADDNULL(inputTrust);
-            }
-            CFRelease(trustSettings);
 
             // Find the creation date.
             jlong creationDate = getModDateFromItem(env, theItem);

--- a/test/jdk/java/security/KeyStore/CheckMacOSKeyChainTrust.java
+++ b/test/jdk/java/security/KeyStore/CheckMacOSKeyChainTrust.java
@@ -1,0 +1,119 @@
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.KeyStore;
+import java.util.HashSet;
+import java.util.Set;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/*
+ * @test
+ * @bug 8303465
+ * @library /test/lib
+ * @requires os.family == "mac"
+ * @summary Check whether loading of certificates from MacOS Keychain correctly
+ *          honors trust settings
+ */
+public class CheckMacOSKeyChainTrust {
+    private static Set<String> trusted = new HashSet<>();
+    private static Set<String> distrusted = new HashSet<>();
+
+    public static void main(String[] args) throws Throwable {
+        loadUser();
+        loadAdmin();
+        System.out.println("Trusted Certs: " + trusted);
+        System.out.println("Distrusted Certs: " + distrusted);
+        KeyStore ks = KeyStore.getInstance("KEYCHAINSTORE");
+        ks.load(null, null);
+        for (String alias : trusted) {
+            if (!ks.containsAlias(alias)) {
+                throw new RuntimeException("Not found: " + alias);
+            }
+        }
+        for (String alias : distrusted) {
+            if (ks.containsAlias(alias)) {
+                throw new RuntimeException("Found: " + alias);
+            }
+        }
+    }
+
+    private static void loadUser() throws Throwable {
+        populate(ProcessTools.executeProcess("security", "dump-trust-settings"));
+    }
+
+    private static void loadAdmin() throws Throwable {
+        populate(ProcessTools.executeProcess("security", "dump-trust-settings", "-d"));
+    }
+
+    private static void populate(OutputAnalyzer output) throws Throwable {
+        if (output.getExitValue() != 0) {
+            return; // No Trust Settings were found
+        }
+        String certName = null;
+        boolean trustRootFound = false;
+        boolean trustAsRootFound = false;
+        boolean denyFound = false;
+        boolean unspecifiedFound = false;
+        for (String line : output.asLines()) {
+            if (line.startsWith("Cert ")) {
+                if (certName != null) {
+                    if (!denyFound &&
+                        !(unspecifiedFound && !(trustRootFound || trustAsRootFound)) &&
+                        !distrusted.contains(certName)) {
+                        trusted.add(certName);
+                    } else {
+                        distrusted.add(certName);
+                        trusted.remove(certName);
+                    }
+                }
+                certName = line.split(":", 2)[1].trim().toLowerCase();
+                trustRootFound = false;
+                trustAsRootFound = false;
+                denyFound = false;
+                unspecifiedFound = false;
+            } else if (line.contains("kSecTrustSettingsResultTrustRoot")) {
+                trustRootFound = true;
+            } else if (line.contains("kSecTrustSettingsResultTrustAsRoot")) {
+                trustAsRootFound = true;
+            } else if (line.contains("kSecTrustSettingsResultDeny")) {
+                denyFound = true;
+            } else if (line.contains("kSecTrustSettingsResultUnspecified")) {
+                unspecifiedFound = true;
+            }
+        }
+        if (certName != null) {
+            if (!denyFound &&
+                !(unspecifiedFound && !(trustRootFound || trustAsRootFound)) &&
+                !distrusted.contains(certName)) {
+                trusted.add(certName);
+            } else {
+                distrusted.add(certName);
+                trusted.remove(certName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8303465](https://bugs.openjdk.org/browse/JDK-8303465), commit [ac41c030](https://github.com/openjdk/jdk/commit/ac41c030030c3d31815474c793ac9c420c47e22c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

This is an improvement for the handling of certificates from the MacOSX keychain which regressed since the April 2022 CPU update (17.0.3) and does not show all appropriate certificates that it should do. The fix was just recently submitted in head and came too late for the regular dev cycle for 17.0.8. However, I would ask to include it now in rampdown, since we have an open customer issue that it would solve. Since our customer is consuming the JDK via Eclipse/Adoptium, it would also not suffice to cherry-pick it into the SapMachine build only, so that's why my request to take it into 17.0.8.

The backport applied cleanly. It involves a CSR but the original CSR has been approved for all relevant backport releases.

Thanks
Christoph