### PR TITLE
Fix potential bugs in `/configure`.

### DIFF
--- a/configure
+++ b/configure
@@ -26,10 +26,10 @@
 # make sure that is called using bash.
 
 # Get an absolute path to this script, since that determines the top-level directory.
-this_script_dir=`dirname $0`
-this_script_dir=`cd $this_script_dir > /dev/null && pwd`
+this_script_dir=`dirname "$0"`
+this_script_dir=`cd "$this_script_dir" > /dev/null && pwd`
 
 # Delegate to wrapper, forcing wrapper to believe $0 is this script by using -c.
 # This trick is needed to get autoconf to co-operate properly.
 # The ${-:+-$-} construction passes on bash options.
-bash ${-:+-$-} -c ". $this_script_dir/make/autoconf/configure" $this_script_dir/configure CHECKME $this_script_dir "$@"
+bash ${-:+-$-} -c ". \"$this_script_dir\"/make/autoconf/configure" "$this_script_dir"/configure CHECKME "$this_script_dir" "$@"


### PR DESCRIPTION
Quote `$this_script_dir` and `$0` to prevent potential bugs when their values contain whitespaces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/379/head:pull/379` \
`$ git checkout pull/379`

Update a local copy of the PR: \
`$ git checkout pull/379` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 379`

View PR using the GUI difftool: \
`$ git pr show -t 379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/379.diff">https://git.openjdk.org/jdk17u/pull/379.diff</a>

</details>
