### PR TITLE
8316566: RISC-V: Zero extended narrow oop passed to Atomic::cmpxchg

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
@@ -37,7 +37,7 @@ inline void OrderAccess::storestore() { release(); }
 inline void OrderAccess::loadstore()  { acquire(); }
 inline void OrderAccess::storeload()  { fence(); }
 
-#define FULL_MEM_BARRIER  __sync_synchronize()
+#define FULL_MEM_BARRIER  __atomic_thread_fence(__ATOMIC_SEQ_CST);
 #define READ_MEM_BARRIER  __atomic_thread_fence(__ATOMIC_ACQUIRE);
 #define WRITE_MEM_BARRIER __atomic_thread_fence(__ATOMIC_RELEASE);
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2d154fcd](https://github.com/openjdk/jdk/commit/2d154fcd0de0612f58abbc5027f409b9b2eb0dc2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Robbin Ehn on 28 Sep 2023 and was reviewed by Ludovic Henry and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316566](https://bugs.openjdk.org/browse/JDK-8316566): RISC-V: Zero extended narrow oop passed to Atomic::cmpxchg (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/381/head:pull/381` \
`$ git checkout pull/381`

Update a local copy of the PR: \
`$ git checkout pull/381` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 381`

View PR using the GUI difftool: \
`$ git pr show -t 381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/381.diff">https://git.openjdk.org/jdk17u/pull/381.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/381#issuecomment-1746395887)