### PR TITLE
8272903: Missing license header in ArenaAllocator.java

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.MemorySegment;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [96614da0](https://github.com/openjdk/jdk/commit/96614da0254e7fd4ac9dd3c3059bf23c1aaf37ff) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Maurizio Cimadamore on 9 Sep 2021 and was reviewed by Brian Burkhalter and Lance Andersen.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8272903](https://bugs.openjdk.org/browse/JDK-8272903) needs maintainer approval

### Issue
 * [JDK-8272903](https://bugs.openjdk.org/browse/JDK-8272903): Missing license header in ArenaAllocator.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/388/head:pull/388` \
`$ git checkout pull/388`

Update a local copy of the PR: \
`$ git checkout pull/388` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 388`

View PR using the GUI difftool: \
`$ git pr show -t 388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/388.diff">https://git.openjdk.org/jdk17u/pull/388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/388#issuecomment-1966870638)