### PR TITLE
8338696: (fs) BasicFileAttributes.creationTime() falls back to epoch if birth time is unavailable (Linux)

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -154,9 +154,10 @@ struct my_statx
 #define STATX_MODE 0x00000002U
 #endif
 
-#ifndef STATX_ALL
-#define STATX_ALL (STATX_BTIME | STATX_BASIC_STATS)
-#endif
+//
+// STATX_ALL is deprecated; use a different name to avoid confusion.
+//
+#define LOCAL_STATX_ALL (STATX_BASIC_STATS | STATX_BTIME)
 
 #ifndef AT_FDCWD
 #define AT_FDCWD -100
@@ -632,8 +633,19 @@ static void copy_statx_attributes(JNIEnv* env, struct my_statx* buf, jobject att
     (*env)->SetLongField(env, attrs, attrs_st_atime_sec, (jlong)buf->stx_atime.tv_sec);
     (*env)->SetLongField(env, attrs, attrs_st_mtime_sec, (jlong)buf->stx_mtime.tv_sec);
     (*env)->SetLongField(env, attrs, attrs_st_ctime_sec, (jlong)buf->stx_ctime.tv_sec);
-    (*env)->SetLongField(env, attrs, attrs_st_birthtime_sec, (jlong)buf->stx_btime.tv_sec);
-    (*env)->SetLongField(env, attrs, attrs_st_birthtime_nsec, (jlong)buf->stx_btime.tv_nsec);
+    if ((buf->stx_mask & STATX_BTIME) != 0) {
+        //  Birth time was filled in so use it
+        (*env)->SetLongField(env, attrs, attrs_st_birthtime_sec,
+                             (jlong)buf->stx_btime.tv_sec);
+        (*env)->SetLongField(env, attrs, attrs_st_birthtime_nsec,
+                             (jlong)buf->stx_btime.tv_nsec);
+    } else {
+        //  Birth time was not filled in: fall back to last modification time
+        (*env)->SetLongField(env, attrs, attrs_st_birthtime_sec,
+                             (jlong)buf->stx_mtime.tv_sec);
+        (*env)->SetLongField(env, attrs, attrs_st_birthtime_nsec,
+                             (jlong)buf->stx_mtime.tv_nsec);
+    }
     (*env)->SetLongField(env, attrs, attrs_st_atime_nsec, (jlong)buf->stx_atime.tv_nsec);
     (*env)->SetLongField(env, attrs, attrs_st_mtime_nsec, (jlong)buf->stx_mtime.tv_nsec);
     (*env)->SetLongField(env, attrs, attrs_st_ctime_nsec, (jlong)buf->stx_ctime.tv_nsec);
@@ -687,7 +699,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_stat0(JNIEnv* env, jclass this,
 #if defined(__linux__)
     struct my_statx statx_buf;
     int flags = AT_STATX_SYNC_AS_STAT;
-    unsigned int mask = STATX_ALL;
+    unsigned int mask = LOCAL_STATX_ALL;
 
     if (my_statx_func != NULL) {
         // Prefer statx over stat64 on Linux if it's available
@@ -748,7 +760,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_lstat0(JNIEnv* env, jclass this,
 #if defined(__linux__)
     struct my_statx statx_buf;
     int flags = AT_STATX_SYNC_AS_STAT | AT_SYMLINK_NOFOLLOW;
-    unsigned int mask = STATX_ALL;
+    unsigned int mask = LOCAL_STATX_ALL;
 
     if (my_statx_func != NULL) {
         // Prefer statx over stat64 on Linux if it's available
@@ -779,7 +791,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_fstat(JNIEnv* env, jclass this, jint fd,
 #if defined(__linux__)
     struct my_statx statx_buf;
     int flags = AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT;
-    unsigned int mask = STATX_ALL;
+    unsigned int mask = LOCAL_STATX_ALL;
 
     if (my_statx_func != NULL) {
         // statx supports FD use via dirfd iff pathname is an empty string and the
@@ -812,7 +824,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_fstatat0(JNIEnv* env, jclass this, jint dfd
 #if defined(__linux__)
     struct my_statx statx_buf;
     int flags = AT_STATX_SYNC_AS_STAT;
-    unsigned int mask = STATX_ALL;
+    unsigned int mask = LOCAL_STATX_ALL;
 
     if (my_statx_func != NULL) {
         // Prefer statx over stat64 on Linux if it's available


### PR DESCRIPTION
Clean backport to improve compatibility with JDK 17 versions which didn't support birth time (`17.0.10` and earlier). I.e. on those systems now last-modified-time is being returned when the statx syscall didn't fill in the birth time (is not supported for this filesystem). In `17.0.11` the epoch (or `0`) is returned for filesystems not supporting creation time. Proposing as a critical fix so as to get it into 17.0.13.

CSR for 21-pool and 17-pool is the same as for JDK head.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8338696](https://bugs.openjdk.org/browse/JDK-8338696) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8339373](https://bugs.openjdk.org/browse/JDK-8339373) to be approved

### Issues
 * [JDK-8338696](https://bugs.openjdk.org/browse/JDK-8338696): (fs) BasicFileAttributes.creationTime() falls back to epoch if birth time is unavailable (Linux) (**Bug** - P3 - Approved)
 * [JDK-8339373](https://bugs.openjdk.org/browse/JDK-8339373): (fs) BasicFileAttributes.creationTime() falls back to epoch if birth time is unavailable (Linux) (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/395/head:pull/395` \
`$ git checkout pull/395`

Update a local copy of the PR: \
`$ git checkout pull/395` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 395`

View PR using the GUI difftool: \
`$ git pr show -t 395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/395.diff">https://git.openjdk.org/jdk17u/pull/395.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/395#issuecomment-2329556827)