### PR TITLE
8339869: [21u] Test CreationTime.java fails with UnsatisfiedLinkError after 8334339

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -27,7 +27,8 @@
  *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
- * @run main/native CreationTime
+ * @comment We see this failing with "UnsatisfiedLinkError: Native Library ...libCreationTimeHelper.so already loaded in another classloader". Thus run as othervm
+ * @run main/othervm CreationTime
  */
 
 /* @test id=cwd


### PR DESCRIPTION
Backport from jdk21u.

Testing:
The failure was sporadic, but we saw it in our 4 daily test runs (21u, 21u-dev, 17u, 17u-dev) about once a day. Since adding this fix temporary to the four test setups on September 3rd, we have not encountered the problem again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339869](https://bugs.openjdk.org/browse/JDK-8339869) needs maintainer approval

### Issue
 * [JDK-8339869](https://bugs.openjdk.org/browse/JDK-8339869): [21u] Test CreationTime.java fails with UnsatisfiedLinkError after 8334339 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/398/head:pull/398` \
`$ git checkout pull/398`

Update a local copy of the PR: \
`$ git checkout pull/398` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 398`

View PR using the GUI difftool: \
`$ git pr show -t 398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/398.diff">https://git.openjdk.org/jdk17u/pull/398.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/398#issuecomment-2343501777)