### PR TITLE
8341059: Change Entrust TLS distrust date to November 12, 2024

### DIFF
--- a/src/java.base/share/classes/sun/security/validator/CADistrustPolicy.java
+++ b/src/java.base/share/classes/sun/security/validator/CADistrustPolicy.java
@@ -57,7 +57,7 @@ enum CADistrustPolicy {
 
     /**
      * Distrust TLS Server certificates anchored by an Entrust root CA and
-     * issued after October 31, 2024. If enabled, this policy is currently
+     * issued after November 11, 2024. If enabled, this policy is currently
      * enforced by the PKIX and SunX509 TrustManager implementations
      * of the SunJSSE provider implementation.
      */

--- a/src/java.base/share/classes/sun/security/validator/EntrustTLSPolicy.java
+++ b/src/java.base/share/classes/sun/security/validator/EntrustTLSPolicy.java
@@ -88,8 +88,8 @@ final class EntrustTLSPolicy {
 
     // Any TLS Server certificate that is anchored by one of the Entrust
     // roots above and is issued after this date will be distrusted.
-    private static final LocalDate OCTOBER_31_2024 =
-        LocalDate.of(2024, Month.OCTOBER, 31);
+    private static final LocalDate NOVEMBER_11_2024 =
+        LocalDate.of(2024, Month.NOVEMBER, 11);
 
     /**
      * This method assumes the eeCert is a TLS Server Cert and chains back to
@@ -111,8 +111,8 @@ final class EntrustTLSPolicy {
             Date notBefore = chain[0].getNotBefore();
             LocalDate ldNotBefore = LocalDate.ofInstant(notBefore.toInstant(),
                                                         ZoneOffset.UTC);
-            // reject if certificate is issued after October 31, 2024
-            checkNotBefore(ldNotBefore, OCTOBER_31_2024, anchor);
+            // reject if certificate is issued after November 11, 2024
+            checkNotBefore(ldNotBefore, NOVEMBER_11_2024, anchor);
         }
     }
 

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1282,7 +1282,7 @@ jdk.sasl.disabledMechanisms=
 #        Distrust after December 31, 2019.
 #
 #   ENTRUST_TLS : Distrust TLS Server certificates anchored by
-#   an Entrust root CA and issued after October 31, 2024.
+#   an Entrust root CA and issued after November 11, 2024.
 #
 # Leading and trailing whitespace surrounding each value are ignored.
 # Unknown values are ignored. If the property is commented out or set to the

--- a/test/jdk/sun/security/ssl/X509TrustManagerImpl/Entrust/Distrust.java
+++ b/test/jdk/sun/security/ssl/X509TrustManagerImpl/Entrust/Distrust.java
@@ -35,7 +35,7 @@ import jdk.test.lib.security.SecurityUtils;
 
 /**
  * @test
- * @bug 8337664
+ * @bug 8337664 8341059
  * @summary Check that TLS Server certificates chaining back to distrusted
  *          Entrust roots are invalid
  * @library /test/lib
@@ -59,14 +59,14 @@ public class Distrust {
         "affirmtrustpremiumca", "affirmtrustpremiumeccca" };
 
     // A date that is after the restrictions take effect
-    private static final Date NOVEMBER_1_2024 =
-        Date.from(LocalDate.of(2024, 11, 1)
+    private static final Date NOVEMBER_12_2024 =
+        Date.from(LocalDate.of(2024, 11, 12)
                            .atStartOfDay(ZoneOffset.UTC)
                            .toInstant());
 
     // A date that is a second before the restrictions take effect
-    private static final Date BEFORE_NOVEMBER_1_2024 =
-        Date.from(LocalDate.of(2024, 11, 1)
+    private static final Date BEFORE_NOVEMBER_12_2024 =
+        Date.from(LocalDate.of(2024, 11, 12)
                            .atStartOfDay(ZoneOffset.UTC)
                            .minusSeconds(1)
                            .toInstant());
@@ -84,7 +84,7 @@ public class Distrust {
             Security.setProperty("jdk.security.caDistrustPolicies", "");
         }
 
-        Date notBefore = before ? BEFORE_NOVEMBER_1_2024 : NOVEMBER_1_2024;
+        Date notBefore = before ? BEFORE_NOVEMBER_12_2024 : NOVEMBER_12_2024;
 
         X509TrustManager pkixTM = getTMF("PKIX", null);
         X509TrustManager sunX509TM = getTMF("SunX509", null);


### PR DESCRIPTION
The very same patch applies clean as in jdk21u. 
Once the change to 21u is pushed, I will update the title and it should be marked as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341059](https://bugs.openjdk.org/browse/JDK-8341059) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8341087](https://bugs.openjdk.org/browse/JDK-8341087) to be approved

### Issues
 * [JDK-8341059](https://bugs.openjdk.org/browse/JDK-8341059): Change Entrust TLS distrust date to November 12, 2024 (**Enhancement** - P2 - Approved)
 * [JDK-8341087](https://bugs.openjdk.org/browse/JDK-8341087): Change Entrust TLS distrust date to November 12, 2024 (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/402/head:pull/402` \
`$ git checkout pull/402`

Update a local copy of the PR: \
`$ git checkout pull/402` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 402`

View PR using the GUI difftool: \
`$ git pr show -t 402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/402.diff">https://git.openjdk.org/jdk17u/pull/402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/402#issuecomment-2384915011)