### PR TITLE
8338751: ConfigureNotify behavior has changed in KWin 6.2

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -772,6 +772,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
             // TODO this should be the default for every case.
             switch (runningWM) {
                 case XWM.CDE_WM:
+                case XWM.KDE2_WM:
                 case XWM.MOTIF_WM:
                 case XWM.METACITY_WM:
                 case XWM.MUTTER_WM:


### PR DESCRIPTION
This is needed to fix popups being placed incorrectly in applications running on Plasma 6.2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8338751](https://bugs.openjdk.org/browse/JDK-8338751) needs maintainer approval

### Issue
 * [JDK-8338751](https://bugs.openjdk.org/browse/JDK-8338751): ConfigureNotify behavior has changed in KWin 6.2 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/404/head:pull/404` \
`$ git checkout pull/404`

Update a local copy of the PR: \
`$ git checkout pull/404` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 404`

View PR using the GUI difftool: \
`$ git pr show -t 404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/404.diff">https://git.openjdk.org/jdk17u/pull/404.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/404#issuecomment-2427569046)