### PR TITLE
Backport 4d3a3c0ebf3f0936846d4ce08e03b9422a1d4d9e

### DIFF
--- a/make/data/tzdata/zone.tab
+++ b/make/data/tzdata/zone.tab
@@ -333,7 +333,7 @@ PF	-0900-13930	Pacific/Marquesas	Marquesas Islands
 PF	-2308-13457	Pacific/Gambier	Gambier Islands
 PG	-0930+14710	Pacific/Port_Moresby	most of Papua New Guinea
 PG	-0613+15534	Pacific/Bougainville	Bougainville
-PH	+1435+12100	Asia/Manila
+PH	+143512+1205804	Asia/Manila
 PK	+2452+06703	Asia/Karachi
 PL	+5215+02100	Europe/Warsaw
 PM	+4703-05620	America/Miquelon


### PR DESCRIPTION
As with [21u](https://github.com/openjdk/jdk21u/pull/460), the [17u backport](https://git.openjdk.org/jdk17u-dev/commit/06ea6d5c17899df8fd83d0b14983c7c1e88d9cde) of the tzdata 2025a update missed an update to zone.tab, as this was not present in the [25u commit](https://git.openjdk.org/jdk/commit/caa3c78f7837b1f561740184bd8f9cb671c467eb) on which it was originally based, due to its removal in [JDK-8166983](https://bugs.openjdk.org/browse/JDK-8166983). The change was in [the 24u commit](https://git.openjdk.org/jdk24u/commit/81252ef76899ad95197550a11c2786ccf3cf0cd2) which was applied later than the 21u one.

We should add this missing change to the existing 2025a update in 17.0.15 and consider backporting JDK-8166983 for 17.0.16 (now proposed for [24u](https://github.com/openjdk/jdk24u/pull/150)).

Backport from 21u is clean. Testspass:
~~~
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/java/text/Format                     111   111     0     0   
   jtreg:test/jdk/java/util/TimeZone                    25    25     0     0   
   jtreg:test/jdk/sun/util/calendar                      5     5     0     0   
   jtreg:test/jdk/sun/util/resources                    22    22     0     0   
   jtreg:test/jdk/java/time                            186   186     0     0   
==============================
TEST SUCCESS
~~~