### PR TITLE
8367388: Tests start to fail on JDK-21 after JDK-8351907

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/screencast/XdgDesktopPortal.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/XdgDesktopPortal.java
@@ -29,6 +29,8 @@ import sun.awt.SunToolkit;
 import sun.awt.UNIXToolkit;
 
 import java.awt.Toolkit;
+import java.security.AccessController;
+import sun.security.action.GetPropertyAction;
 
 public class XdgDesktopPortal {
     private static final String METHOD_X11 = "x11";
@@ -62,7 +64,11 @@ public class XdgDesktopPortal {
                     : METHOD_SCREENCAST;
         }
 
-        String m = System.getProperty("awt.robot.screenshotMethod", defaultMethod);
+        @SuppressWarnings("removal")
+        String m = AccessController.doPrivileged(
+                new GetPropertyAction(
+                        "awt.robot.screenshotMethod", defaultMethod
+                ));
 
         if (!METHOD_REMOTE_DESKTOP.equals(m)
                 && !METHOD_SCREENCAST.equals(m)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [dea855e1](https://github.com/openjdk/jdk21u/commit/dea855e163572dc4a1761f5aefe89c148d75c9bf) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository.

The commit being backported was authored by Sergey Bylokhov on 19 Sep 2025 and was reviewed by Paul Hohensee.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367388](https://bugs.openjdk.org/browse/JDK-8367388) needs maintainer approval

### Issue
 * [JDK-8367388](https://bugs.openjdk.org/browse/JDK-8367388): Tests start to fail on JDK-21 after JDK-8351907 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/410/head:pull/410` \
`$ git checkout pull/410`

Update a local copy of the PR: \
`$ git checkout pull/410` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 410`

View PR using the GUI difftool: \
`$ git pr show -t 410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/410.diff">https://git.openjdk.org/jdk17u/pull/410.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/410#issuecomment-3313175959)
</details>
