### PR TITLE
8374548: Process httpserver cancelled keys more quickly

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -636,6 +636,18 @@ class ServerImpl {
         public void run () {
             /* context will be null for new connections */
             logger.log(Level.TRACE, "exchange started");
+
+            if (dispatcherThread == Thread.currentThread()) {
+                try {
+                    // call selector to process cancelled keys
+                    selector.selectNow();
+                } catch (IOException ioe) {
+                    logger.log(Level.DEBUG, "processing of cancelled keys failed: closing");
+                    closeConnection(connection);
+                    return;
+                }
+            }
+
             context = connection.getHttpContext();
             boolean newconnection;
             SSLEngine engine = null;


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8374548 "Process httpserver cancelled keys more quickly" was opened for 17, but in reality it is a backport of the functional change of https://bugs.openjdk.org/browse/JDK-8278398 "jwebserver: Add test to confirm maximum request time". The newly added test surfaced an issue in the httpserver implementation which was fixed right away.  But the title mentions jwebserver, which was added in 18 by https://bugs.openjdk.org/browse/JDK-8260510: "JEP 408: Simple Web Server". As jwebserver is not in 17, the title is not appropriate in 17, so they probably opened a bug with a better title, or used an existing bug to backport the issue. Thus a bit of confusing JBS issues here.

I will handle this as 'backport' from 17.0.19-oracle to open 17.0.20.
The chunk for ServerImpl.java applies clean.

The new test depends heavily on jwebserver, thus does not work in 17.
Luckily the test added by https://bugs.openjdk.org/browse/JDK-8304065: "HttpServer.stop should terminate immediately if no exchanges are in progress" is a good reproducer: it fails without this change. I will backport that change, too. So I think we can go without MaxRequestTimeTest.java and rely on ServerStopTerminationTest.java for testing.

I would like to get this into 17.0.20, as it's already in 17.0.19-oracle. Also, it is a follow-up to the larger http remake that was added to 17 last year.  I will also backport https://bugs.openjdk.org/browse/JDK-8304065 and https://bugs.openjdk.org/browse/JDK-8376031 which all depend on each other.

Test in JDK-8304065 passes with this change, SAP nightly testing passed (together with JDK-8304065).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8374548](https://bugs.openjdk.org/browse/JDK-8374548) needs maintainer approval

### Issue
 * [JDK-8374548](https://bugs.openjdk.org/browse/JDK-8374548): Process httpserver cancelled keys more quickly (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/427/head:pull/427` \
`$ git checkout pull/427`

Update a local copy of the PR: \
`$ git checkout pull/427` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 427`

View PR using the GUI difftool: \
`$ git pr show -t 427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/427.diff">https://git.openjdk.org/jdk17u/pull/427.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/427#issuecomment-4610255615)
</details>
