### PR TITLE
8354469: Keytool exposes the password in plain text when command is piped using | grep

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -383,7 +383,9 @@ public final class Console implements Flushable
                             ioe.addSuppressed(x);
                     }
                     if (ioe != null) {
-                        Arrays.fill(passwd, ' ');
+                        if (passwd != null) {
+                            Arrays.fill(passwd, ' ');
+                        }
                         try {
                             if (reader instanceof LineReader lr) {
                                 lr.zeroOut();

--- a/src/java.base/share/classes/sun/security/util/Password.java
+++ b/src/java.base/share/classes/sun/security/util/Password.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class Password {
 
         try {
             // Use the new java.io.Console class
-            Console con = null;
+            Console con;
             if (!isEchoOn && in == System.in && ((con = System.console()) != null)) {
                 consoleEntered = con.readPassword();
                 // readPassword returns "" if you just print ENTER,
@@ -69,7 +69,6 @@ public class Password {
 
             char[] lineBuffer;
             char[] buf;
-            int i;
 
             buf = lineBuffer = new char[128];
 

--- a/src/java.base/share/classes/sun/security/util/Password.java
+++ b/src/java.base/share/classes/sun/security/util/Password.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,10 @@ import java.nio.*;
 import java.nio.charset.*;
 import java.util.Arrays;
 
+import jdk.internal.access.SharedSecrets;
+
 /**
  * A utility class for reading passwords
- *
  */
 public class Password {
     /** Reads user password from given input stream. */
@@ -49,28 +50,36 @@ public class Password {
 
         char[] consoleEntered = null;
         byte[] consoleBytes = null;
+        char[] buf = null;
 
         try {
             // Use the new java.io.Console class
-            Console con;
-            if (!isEchoOn && in == System.in && ((con = System.console()) != null)) {
-                consoleEntered = con.readPassword();
-                // readPassword returns "" if you just print ENTER,
-                // to be compatible with old Password class, change to null
-                if (consoleEntered != null && consoleEntered.length == 0) {
-                    return null;
+            if (!isEchoOn) {
+                if (in == System.in
+                        && ConsoleHolder.consoleIsAvailable()) {
+                    consoleEntered = ConsoleHolder.readPassword();
+                    // readPassword might return null. Stop now.
+                    if (consoleEntered == null) {
+                        return null;
+                    }
+                    consoleBytes = ConsoleHolder.convertToBytes(consoleEntered);
+                    in = new ByteArrayInputStream(consoleBytes);
+                } else if (System.in.available() == 0) {
+                    // This may be running in an IDE Run Window or in JShell,
+                    // which acts like an interactive console and echoes the
+                    // entered password. In this case, print a warning that
+                    // the password might be echoed. If available() is not zero,
+                    // it's more likely the input comes from a pipe, such as
+                    // "echo password |" or "cat password_file |" where input
+                    // will be silently consumed without echoing to the screen.
+                    System.err.print(ResourcesMgr.getString
+                            ("warning.input.may.be.visible.on.screen"));
                 }
-                consoleBytes = convertToBytes(consoleEntered);
-                in = new ByteArrayInputStream(consoleBytes);
             }
 
             // Rest of the lines still necessary for KeyStoreLoginModule
             // and when there is no console.
-
-            char[] lineBuffer;
-            char[] buf;
-
-            buf = lineBuffer = new char[128];
+            buf = new char[128];
 
             int room = buf.length;
             int offset = 0;
@@ -98,11 +107,11 @@ public class Password {
                     /* fall through */
                   default:
                     if (--room < 0) {
+                        char[] oldBuf = buf;
                         buf = new char[offset + 128];
                         room = buf.length - offset - 1;
-                        System.arraycopy(lineBuffer, 0, buf, 0, offset);
-                        Arrays.fill(lineBuffer, ' ');
-                        lineBuffer = buf;
+                        System.arraycopy(oldBuf, 0, buf, 0, offset);
+                        Arrays.fill(oldBuf, ' ');
                     }
                     buf[offset++] = (char) c;
                     break;
@@ -115,8 +124,6 @@ public class Password {
 
             char[] ret = new char[offset];
             System.arraycopy(buf, 0, ret, 0, offset);
-            Arrays.fill(buf, ' ');
-
             return ret;
         } finally {
             if (consoleEntered != null) {
@@ -125,35 +132,74 @@ public class Password {
             if (consoleBytes != null) {
                 Arrays.fill(consoleBytes, (byte)0);
             }
+            if (buf != null) {
+                Arrays.fill(buf, ' ');
+            }
         }
     }
 
-    /**
-     * Change a password read from Console.readPassword() into
-     * its original bytes.
-     *
-     * @param pass a char[]
-     * @return its byte[] format, similar to new String(pass).getBytes()
-     */
-    private static byte[] convertToBytes(char[] pass) {
-        if (enc == null) {
-            synchronized (Password.class) {
-                enc = System.console()
-                        .charset()
-                        .newEncoder()
-                        .onMalformedInput(CodingErrorAction.REPLACE)
-                        .onUnmappableCharacter(CodingErrorAction.REPLACE);
+    // Everything on Console is inside this class.
+    private static class ConsoleHolder {
+
+        // primary console; may be null
+        private static final Console c1;
+        // secondary console (when stdout is redirected); may be null
+        private static final Console c2;
+        // encoder for c1 or c2
+        private static final CharsetEncoder enc;
+
+        static {
+            c1 = System.console();
+            Charset charset;
+            if (c1 != null) {
+                c2 = null;
+                charset = c1.charset();
+            } else {
+                c2 = SharedSecrets.getJavaIOAccess().passwordConsole()
+                        .orElse(null);
+                charset = (c2 != null) ? c2.charset() : null;
+            }
+            enc = charset == null ? null : charset.newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPLACE)
+                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
+        }
+
+        public static boolean consoleIsAvailable() {
+            return c1 != null || c2 != null;
+        }
+
+        public static char[] readPassword() {
+            assert consoleIsAvailable();
+            if (c1 != null) {
+                return c1.readPassword();
+            } else {
+                try {
+                    return SharedSecrets.getJavaIOAccess()
+                            .readPasswordNoNewLine(c2);
+                } finally {
+                    System.err.println();
+                }
             }
         }
-        byte[] ba = new byte[(int)(enc.maxBytesPerChar() * pass.length)];
-        ByteBuffer bb = ByteBuffer.wrap(ba);
-        synchronized (enc) {
-            enc.reset().encode(CharBuffer.wrap(pass), bb, true);
+
+        /**
+         * Convert a password read from console into its original bytes.
+         *
+         * @param pass a char[]
+         * @return its byte[] format, equivalent to new String(pass).getBytes()
+         *      but String is immutable and cannot be cleaned up.
+         */
+        public static byte[] convertToBytes(char[] pass) {
+            assert consoleIsAvailable();
+            byte[] ba = new byte[(int) (enc.maxBytesPerChar() * pass.length)];
+            ByteBuffer bb = ByteBuffer.wrap(ba);
+            synchronized (enc) {
+                enc.reset().encode(CharBuffer.wrap(pass), bb, true);
+            }
+            if (bb.remaining() > 0) {
+                bb.put((byte)'\n'); // will be recognized as a stop sign
+            }
+            return ba;
         }
-        if (bb.position() < ba.length) {
-            ba[bb.position()] = '\n';
-        }
-        return ba;
     }
-    private static volatile CharsetEncoder enc;
 }

--- a/src/java.base/share/classes/sun/security/util/Resources.java
+++ b/src/java.base/share/classes/sun/security/util/Resources.java
@@ -138,6 +138,10 @@ public class Resources extends java.util.ListResourceBundle {
         // sun.security.pkcs11.SunPKCS11
         {"PKCS11.Token.providerName.Password.",
                 "PKCS11 Token [{0}] Password: "},
+
+        // sun.security.util.Password
+        {"warning.input.may.be.visible.on.screen",
+                "[WARNING: Input may be visible on screen]\u0020"},
     };
 
 

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8354469
+ * @summary keytool password does not echo in multiple cases
+ * @library /java/awt/regtesthelpers
+ * @modules java.base/jdk.internal.util
+ * @build PassFailJFrame
+ * @run main/manual/othervm EchoPassword
+ */
+
+import jdk.internal.util.OperatingSystem;
+
+import javax.swing.JEditorPane;
+import javax.swing.JLabel;
+import javax.swing.event.HyperlinkEvent;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.io.File;
+import java.nio.file.Path;
+
+public class EchoPassword {
+
+    static JLabel label;
+
+    public static void main(String[] args) throws Exception {
+
+        var ks1 = "\"" + Path.of("8354469.ks1").toAbsolutePath() + "\"";
+        var ks2 = "\"" + Path.of("8354469.ks2").toAbsolutePath() + "\"";
+        var ks3 = "\"" + Path.of("8354469.ks3").toAbsolutePath() + "\"";
+
+        final String keytool = "\"" + System.getProperty("java.home")
+                + File.separator + "bin" + File.separator + "keytool\"";
+        final String nonASCII = "äöäöäöäö";
+
+        final String[][] commands = {
+                // Input password from real Console
+                {"First command", keytool + " -keystore " + ks1
+                        + " -genkeypair -keyalg ec -dname cn=a -alias first"},
+                // Input password from limited Console (when stdout is redirected)
+                {"Second command", keytool + " -keystore " + ks2
+                        + " -genkeypair -keyalg ec -dname cn=b -alias second | sort"},
+                // Input password from System.in stream
+                {"Third command", "echo changeit| " + keytool + " -keystore " + ks1
+                        + " -genkeypair -keyalg ec -dname cn=c -alias third"},
+                // Ensure limited Console does not write a newline to System.out
+                {"Fourth command", keytool + " -keystore " + ks1
+                        + " -exportcert -alias first | "
+                        + keytool + " -printcert -rfc"},
+                {"The password", nonASCII}
+        };
+
+        final String message = String.format("""
+                <html>Open a terminal or Windows Command Prompt window, perform
+                the following steps, and record the final result. Each time you
+                click a link to copy something, make sure the status line at the
+                bottom shows the link has been successfully clicked.
+                <h3>Part I: Password Echoing Tests</h3>
+                <ol>
+                <li>Click <a href='c0'>Copy First Command</a> to copy the
+                following command into the system clipboard. Paste it into the
+                terminal window and execute the command.
+                <p><code>
+                %s
+                </code><p>
+                When prompted, enter "changeit" and press Enter. When prompted
+                again, enter "changeit" again and press Enter. Verify that the
+                two password prompts show up on different lines, both
+                passwords are hidden, and a key pair is generated successfully.
+
+                <li>Click <a href='c1'>Copy Second Command</a> to copy the
+                following command into the system clipboard. Paste it into the
+                terminal window and execute the command.
+                <p><code>
+                %s
+                </code><p>
+                When prompted, enter "changeit" and press Enter. When prompted
+                again, enter "changeit" again and press Enter. Verify that the
+                two password prompts show up on different lines, both
+                passwords are hidden, and a key pair is generated successfully.
+
+                <li>Click <a href='c2'>Copy Third Command</a> to copy the
+                following command into the system clipboard. Paste it into the
+                terminal window and execute the command.
+                <p><code>
+                %s
+                </code><p>
+                You will see a prompt but you don't need to enter anything.
+                Verify that the password "changeit" is not shown in the command
+                output and a key pair is generated successfully.
+
+                <li>Click <a href='c3'>Copy Fourth Command</a> to copy the
+                following command into the system clipboard. Paste it into the
+                terminal window and execute the command.
+                <p><code>
+                %s
+                </code><p>
+                When prompted, enter "changeit" and press Enter. Verify that the
+                password is hidden and a PEM certificate is correctly shown.
+                </ol>
+                Press "pass" if the behavior matches expectations;
+                otherwise, press "fail".
+                """, commands[0][1], commands[1][1], commands[2][1], commands[3][1],
+                commands[4][1]);
+
+        PassFailJFrame.builder()
+                .instructions(message)
+                .rows(40).columns(100)
+                .hyperlinkListener(e -> {
+                    if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                        int pos = Integer.parseInt(e.getDescription().substring(1));
+                        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(
+                                new StringSelection(commands[pos][1]), null);
+                        label.setText(commands[pos][0] + " copied");
+                        if (e.getSource() instanceof JEditorPane ep) {
+                            ep.getCaret().setVisible(false);
+                        }
+                    }
+                })
+                .splitUIBottom(() -> {
+                    label = new JLabel("Status");
+                    return label;
+                })
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/sun/security/tools/keytool/EchoPassword.java
+++ b/test/jdk/sun/security/tools/keytool/EchoPassword.java
@@ -28,10 +28,9 @@
  * @library /java/awt/regtesthelpers
  * @modules java.base/jdk.internal.util
  * @build PassFailJFrame
+ * @compile -encoding UTF-8 EchoPassword.java
  * @run main/manual/othervm EchoPassword
  */
-
-import jdk.internal.util.OperatingSystem;
 
 import javax.swing.JEditorPane;
 import javax.swing.JLabel;

--- a/test/jdk/sun/security/tools/keytool/SetInPassword.java
+++ b/test/jdk/sun/security/tools/keytool/SetInPassword.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8354469
+ * @summary ensure password can be read from user's System.in
+ * @library /test/lib
+ * @modules java.base/sun.security.tools.keytool
+ */
+
+import jdk.test.lib.SecurityTools;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class SetInPassword {
+    public static void main(String[] args) throws Exception {
+        SecurityTools.keytool("-keystore ks -storepass changeit -genkeypair -alias a -dname CN=A -keyalg EC")
+                .shouldHaveExitValue(0);
+        System.setIn(new ByteArrayInputStream("changeit".getBytes(StandardCharsets.UTF_8)));
+        sun.security.tools.keytool.Main.main("-keystore ks -alias a -certreq".split(" "));
+    }
+}

--- a/test/jdk/sun/security/util/Resources/Usages.java
+++ b/test/jdk/sun/security/util/Resources/Usages.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8215937
+ * @bug 8215937 8354469
  * @modules java.base/sun.security.util
  *          java.base/sun.security.tools.keytool
  *          jdk.jartool/sun.security.tools.jarsigner
@@ -132,6 +132,8 @@ public class Usages {
                             List.of(LOC_GETNONLOC, NEW_LOC)),
                     new Pair("java.base/share/classes/sun/security/provider/PolicyFile.java",
                             List.of(MGR_GETSTRING, LOC_GETNONLOC, LOC_GETNONLOC_POLICY)),
+                    new Pair("java.base/share/classes/sun/security/util/Password.java",
+                            List.of(MGR_GETSTRING)),
                     new Pair("java.base/share/classes/javax/security/auth/",
                             List.of(MGR_GETSTRING)))
     );


### PR DESCRIPTION
This is a backport of `JDK-8354469: Keytool exposes the password in plain text when command is piped using | grep`.  This is a copy of https://github.com/openjdk/jdk17u-dev/pull/4485 for `jdk17u` since we would like this fix in the July release for the reasons @GoeLin listed in https://github.com/openjdk/jdk17u-dev/pull/4485#issuecomment-4609653339.

Code changes:

- Fixes to test `EchoPassword.java` test case:

  - Add `@compile -encoding UTF-8 EchoPassword.java`, otherwise `javac` fails to read the `nonASCII` string

  - Remove `import jdk.internal.util.OperatingSystem;` which is not in 17, and is not used by the test

- Applied src/java.base/share/classes/sun/security/util/Password.java cleanup from `JDK-8291509: Minor cleanup could be done in sun.security`

- On 17, left the `System.in` check as-is: `in == System.in`; in 21, there is further check that System.in is the initial console, `in == SharedSecrets.getJavaLangAccess().initialSystemIn()`

- In Password$ConsoleHolder:

  - Declared c2 as `Console`, versus 21's `JdkConsoleImpl`

  - Replaced `JdkConsoleImpl.passwordConsole()` from 21 with `SharedSecrets.getJavaIOAccess().passwordConsole()`

  - Replace `c2.readPasswordNoNewLine()` with `SharedSecrets.getJavaIOAccess().readPasswordNoNewLine(c2)`

- Confirmed `EchoPassword` passes after patching `src/java.base/share/classes/sun/security/util/Password.java` (also had confirmed it failed on unpatched/existing `src/java.base/share/classes/sun/security/util/Password.java`, so the test is good)

- Confirmed `SetInPassword.java` and `Usages.java` still pass

- Confirmed `sun.security.util.Password.readPassword(InputStream in, boolean isEchoOn)` still returns `null` when the user just presses `Enter` (per the deleted comment)

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8354469](https://bugs.openjdk.org/browse/JDK-8354469) needs maintainer approval

### Issue
 * [JDK-8354469](https://bugs.openjdk.org/browse/JDK-8354469): Keytool exposes the password in plain text when command is piped using | grep (**Enhancement** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/429/head:pull/429` \
`$ git checkout pull/429`

Update a local copy of the PR: \
`$ git checkout pull/429` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 429`

View PR using the GUI difftool: \
`$ git pr show -t 429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/429.diff">https://git.openjdk.org/jdk17u/pull/429.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/429#issuecomment-4613484115)
</details>
