### PR TITLE
8374555: No need for visible input warning in s.s.u.Password when not reading from System.in

### DIFF
--- a/src/java.base/share/classes/sun/security/util/Password.java
+++ b/src/java.base/share/classes/sun/security/util/Password.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.nio.charset.*;
 import java.util.Arrays;
 
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.VM;
 
 /**
  * A utility class for reading passwords
@@ -64,7 +65,9 @@ public class Password {
                     }
                     consoleBytes = ConsoleHolder.convertToBytes(consoleEntered);
                     in = new ByteArrayInputStream(consoleBytes);
-                } else if (System.in.available() == 0) {
+                } else if (in == System.in && VM.isBooted()
+                            && System.in.available() == 0) {
+                    // Warn if reading password from System.in but it's empty.
                     // This may be running in an IDE Run Window or in JShell,
                     // which acts like an interactive console and echoes the
                     // entered password. In this case, print a warning that
@@ -72,6 +75,7 @@ public class Password {
                     // it's more likely the input comes from a pipe, such as
                     // "echo password |" or "cat password_file |" where input
                     // will be silently consumed without echoing to the screen.
+                    // Warn only if VM is booted and ResourcesMgr is available.
                     System.err.print(ResourcesMgr.getString
                             ("warning.input.may.be.visible.on.screen"));
                 }

--- a/test/jdk/sun/security/util/Password/EmptyIn.java
+++ b/test/jdk/sun/security/util/Password/EmptyIn.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.util.Password;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/*
+ * @test
+ * @bug 8374555
+ * @summary only print warning when reading from System.in
+ * @modules java.base/sun.security.util
+ * @library /test/lib
+ */
+public class EmptyIn {
+    public static void main(String[] args) throws Exception {
+        testSystemIn();
+        testNotSystemIn();
+    }
+
+    static void testSystemIn() throws Exception {
+        var in = new ByteArrayInputStream(new byte[0]);
+        var err = new ByteArrayOutputStream();
+        var oldErr = System.err;
+        var oldIn = System.in;
+        try {
+            System.setIn(in);
+            System.setErr(new PrintStream(err));
+            Password.readPassword(System.in);
+        } finally {
+            System.setIn(oldIn);
+            System.setErr(oldErr);
+        }
+        // Read from System.in. Should warn.
+        Asserts.assertNotEquals(0, err.size());
+    }
+
+    static void testNotSystemIn() throws Exception {
+        var in = new ByteArrayInputStream(new byte[0]);
+        var err = new ByteArrayOutputStream();
+        var oldErr = System.err;
+        try {
+            System.setErr(new PrintStream(err));
+            Password.readPassword(in);
+        } finally {
+            System.setErr(oldErr);
+        }
+        // Not read from System.in. Should not warn.
+        Asserts.assertEQ(0, err.size());
+    }
+}


### PR DESCRIPTION
Resolved import in Password.java. Probably clean anyways.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8374555](https://bugs.openjdk.org/browse/JDK-8374555) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8374555](https://bugs.openjdk.org/browse/JDK-8374555): No need for visible input warning in s.s.u.Password when not reading from System.in (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/430/head:pull/430` \
`$ git checkout pull/430`

Update a local copy of the PR: \
`$ git checkout pull/430` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 430`

View PR using the GUI difftool: \
`$ git pr show -t 430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/430.diff">https://git.openjdk.org/jdk17u/pull/430.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/430#issuecomment-4646605969)
</details>
