### PR TITLE
8390380: Cherry-pick metazone changes from CLDR to support tzdata2026c for JDK update releases

### DIFF
--- a/make/data/cldr/common/supplemental/metaZones.xml
+++ b/make/data/cldr/common/supplemental/metaZones.xml
@@ -57,6 +57,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone to="1984-03-16 00:00" mzone="Europe_Western"/>
 				<usesMetazone to="1985-12-31 23:00" from="1984-03-16 00:00" mzone="Europe_Central"/>
 				<usesMetazone to="2018-10-28 02:00" from="1985-12-31 23:00" mzone="Europe_Western"/>
+				<usesMetazone from="2026-09-20 01:00" mzone="Europe_Western"/>
 			</timezone>
 			<timezone type="Africa/Ceuta">
 				<usesMetazone to="1984-03-16 00:00" mzone="Europe_Western"/>
@@ -80,6 +81,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<timezone type="Africa/El_Aaiun">
 				<usesMetazone to="1976-04-14 01:00" mzone="Africa_FarWestern"/>
 				<usesMetazone to="2018-10-28 02:00" from="1976-04-14 01:00" mzone="Europe_Western"/>
+				<usesMetazone from="2026-09-20 01:00" mzone="Europe_Western"/>
 			</timezone>
 			<timezone type="Africa/Freetown">
 				<usesMetazone mzone="GMT"/>
@@ -383,7 +385,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone mzone="Atlantic"/>
 			</timezone>
 			<timezone type="America/Edmonton">
-				<usesMetazone mzone="America_Mountain"/>
+				<usesMetazone mzone="America_Mountain" stdOffset="-07" dstOffset="-06"/>
 			</timezone>
 			<timezone type="America/Eirunepe">
 				<usesMetazone to="2008-06-24 05:00" mzone="Acre"/>
@@ -767,7 +769,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone from="1983-11-30 09:00" mzone="Alaska"/>
 			</timezone>
 			<timezone type="America/Yellowknife">
-				<usesMetazone mzone="America_Mountain"/>
+				<usesMetazone mzone="America_Mountain" stdOffset="-07" dstOffset="-06"/>
 			</timezone>
 			<timezone type="Antarctica/Casey">
 				<usesMetazone to="2009-10-17 18:00" mzone="Australia_Western"/>

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -24,7 +24,7 @@
  /*
  * @test
  * @bug 8181157 8202537 8234347 8236548 8261279 8293834
- *      8381379 8390388
+ *      8381379 8390388 8390380
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at runtime
  * @run junit/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
@@ -208,7 +208,11 @@ public class TimeZoneNamesTest {
             Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Irish Standard Time"),
             Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Greenwich Mean Time"),
             Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time")
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time"),
+            Arguments.of(ZonedDateTime.of(2026, 1, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Standard Time"),
+            Arguments.of(ZonedDateTime.of(2026, 7, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Daylight Time"),
+            Arguments.of(ZonedDateTime.of(2026, 1, 5, 0, 0, 0, 0, ZoneId.of("America/Yellowknife")), "Mountain Standard Time"),
+            Arguments.of(ZonedDateTime.of(2026, 7, 5, 0, 0, 0, 0, ZoneId.of("America/Yellowknife")), "Mountain Daylight Time")
         );
     }
 


### PR DESCRIPTION
This is the second change in the JDK 17 tzdata2026c stack and depends on the JDK-8390388 backport PR (https://github.com/openjdk/jdk17u/pull/439) (integrated).

The only textual conflict was TimeZoneNamesTest.java's bug metadata. I kept JDK 17's existing JDK-8293834 entry and added JDK-8390380.

JDK 17's CLDR 39 data retains a standalone America/Yellowknife metazone entry.

I retained the JDK 21 backport's older-CLDR adaptation, giving Yellowknife the same explicit -07 standard and -06 daylight offsets as Edmonton and retaining the matching winter and summer test cases. Same as 21.

#### Testing
* `make images`
* `make run-test TEST="test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java"`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8390380](https://bugs.openjdk.org/browse/JDK-8390380) needs maintainer approval

### Issue
 * [JDK-8390380](https://bugs.openjdk.org/browse/JDK-8390380): Cherry-pick metazone changes from CLDR to support tzdata2026c for JDK update releases (**Bug** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u.git pull/440/head:pull/440` \
`$ git checkout pull/440`

Update a local copy of the PR: \
`$ git checkout pull/440` \
`$ git pull https://git.openjdk.org/jdk17u.git pull/440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 440`

View PR using the GUI difftool: \
`$ git pr show -t 440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u/pull/440.diff">https://git.openjdk.org/jdk17u/pull/440.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u/pull/440#issuecomment-5577336243)
</details>
